### PR TITLE
Remove 'final' from copy() and toString() in the homography model.

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/HomographyModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/HomographyModel2D.java
@@ -215,7 +215,7 @@ public class HomographyModel2D extends AbstractModel< HomographyModel2D > implem
 	}
 	
 	@Override
-	final public HomographyModel2D copy()
+	public HomographyModel2D copy()
 	{
 		final HomographyModel2D m = new HomographyModel2D();
 		
@@ -373,7 +373,7 @@ public class HomographyModel2D extends AbstractModel< HomographyModel2D > implem
 //	}
 
 	@Override
-	final public String toString()
+	public String toString()
 	{
 //		final double[][] b = a.getArray();
 //		return (


### PR DESCRIPTION
Very minor tweak needed to be able to subclass the model for use as a transform in TrakEM2 in the same style as the other models. Specifically, .copy() needs to be overridden.
