### PR TITLE
Fix version in root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>mpicbg</groupId>
 	<artifactId>pom-mpicbg</artifactId>
-	<version>${mpicbg.version}</version>
+	<version>0.6.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Aggregator project for Stephan Saalfeld's mpicbg library and plugin collection</name>


### PR DESCRIPTION
The groupId, artifactId and version declaring a project (as opposed to a
dependency) cannot be specified via properties. The groupId and version
can be inherited from the <parent> definition, but that does not apply
here.

So let's just set the version explicitly and be done with it.

This fixes the build failures in Jenkins (which does not use
Maven-challenged Eclipse but the real thing):
http://jenkins.imagej.net/job/Saalfeld-MPICBG-Maven/

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
