### PR TITLE
Use pom-scijava for repeatable builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,10 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>1.125</version>
+		<relativePath />
 	</parent>
 
 	<groupId>mpicbg</groupId>
@@ -31,15 +32,11 @@
 		<url>http://fiji.sc/cgi-bin/gitweb.cgi?p=mpicbg.git;a=summary</url>
 	</scm>
 
-	<!-- NB: for project parent -->
 	<repositories>
+		<!-- NB: for project parent -->
 		<repository>
-			<id>imagej.releases</id>
-			<url>http://maven.imagej.net/content/repositories/releases</url>
-		</repository>
-		<repository>
-			<id>imagej.snapshots</id>
-			<url>http://maven.imagej.net/content/repositories/snapshots</url>
+			<id>imagej.public</id>
+			<url>http://maven.imagej.net/content/groups/public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Using a SNAPSHOT parent can cause the parent configuration to shift out
from under the project, resulting in an irreproducible build. Let's use
a release version of pom-scijava instead, to improve build stability.

We use pom-scijava 1.125 because it is the most recent version to
successfully imbue the needed "use=false" hack to maven-javadoc-plugin.
Without that hack, an NPE is thrown during javadoc generation because
the javadoc tool has a long-standing bug when generating package usage
information for classes in the default package.
