### PR TITLE
Bump to latest pom-fiji

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>6.1.1</version>
+		<version>6.1.3</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
Updates pom-fiji to version 6.1.3. This should significantly improve maven-enforcer-plugin performance.
