### PR TITLE
Fix problems with the POM

### DIFF
--- a/mpicbg/pom.xml
+++ b/mpicbg/pom.xml
@@ -30,19 +30,4 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<configuration>
-					<rules>
-						<requireReleaseDeps>
-							<failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
-						</requireReleaseDeps>
-					</rules>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/mpicbg_/pom.xml
+++ b/mpicbg_/pom.xml
@@ -37,22 +37,4 @@
 		</dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<configuration>
-					<rules>
-						<requireReleaseDeps>
-							<failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
-							<excludes>
-								<exclude>mpicbg:mpicbg</exclude>
-							</excludes>
-						</requireReleaseDeps>
-					</rules>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/mpicbg_/pom.xml
+++ b/mpicbg_/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>mpicbg</groupId>
 			<artifactId>mpicbg</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 
 		<!-- ImageJ dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>8.2.0</version>
+		<version>13.0.1</version>
 		<relativePath />
 	</parent>
 


### PR DESCRIPTION
The Fiji build broke due to a tainted release of mpicbg_ 1.0.1. It depends on an mpicbg SNAPSHOT version, even though it purports to be a release version. It looks like an attempt was made to fix this in the Git history, but releases are immutable. A 1.0.2 release is needed after this branch is merged. Then we can update pom-fiji to use 1.0.2 and all will be well.