### PR TITLE
Use the SciJava fork of Java 3D 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>17.0.0</version>
+		<version>18.1.0</version>
 		<relativePath />
 	</parent>
 

--- a/test/movingleastsquarestransform.bsh
+++ b/test/movingleastsquarestransform.bsh
@@ -1,6 +1,6 @@
 import mpicbg.models.MovingLeastSquaresTransform;
-import javax.vecmath.Point3f;
-import javax.vecmath.Color3f;
+import org.scijava.vecmath.Point3f;
+import org.scijava.vecmath.Color3f;
 import ij3d.Image3DUniverse;
 import customnode.CustomPointMesh;
 import customnode.CustomLineMesh;


### PR DESCRIPTION
This means we no longer need users to install a Java 3D into
their Java runtimes -- we can just ship Java 3D with Fiji!

See:
* https://github.com/scijava/vecmath

The only actual usage of Java 3D here is vecmath in a BSH test script.
So this change has essentially no impact on the actual mpicbg libraries.