### PR TITLE
Add developers and contributors

### DIFF
--- a/mpicbg/pom.xml
+++ b/mpicbg/pom.xml
@@ -11,7 +11,6 @@
 	</parent>
 
 	<!-- <properties> <enforcer.skip>true</enforcer.skip> </properties> -->
-
 	<artifactId>mpicbg</artifactId>
 
 	<name>jars/mpicbg.jar</name>
@@ -30,5 +29,4 @@
 			<artifactId>jama</artifactId>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/mpicbg_/pom.xml
+++ b/mpicbg_/pom.xml
@@ -16,7 +16,6 @@
 	<description></description>
 
 	<!-- <properties> <enforcer.skip>true</enforcer.skip> </properties> -->
-
 	<dependencies>
 		<!-- Project dependencies -->
 		<dependency>
@@ -36,5 +35,4 @@
 			<artifactId>jama</artifactId>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,97 @@
 	<name>Aggregator project for Stephan Saalfeld's mpicbg library and plugin collection</name>
 	<description></description>
 
+	<developers>
+		<developer>
+			<id>axtimwalde</id>
+			<name>Stephan Saalfeld</name>
+			<email>saalfelds@janelia.hhmi.org</email>
+			<url>http://www.janelia.org/lab/saalfeld-lab</url>
+			<organization>HHMI Janelia Research Campus</organization>
+			<organizationUrl>http://www.janelia.org/</organizationUrl>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+			<timezone>-5</timezone>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Stephan Preibisch</name>
+			<url>http://imagej.net/User:Preibisch</url>
+			<properties><id>StephanPreibisch</id></properties>
+		</contributor>
+		<contributor>
+			<name>Ignacio Arganda-Carreras</name>
+			<url>http://imagej.net/User:Iarganda</url>
+			<properties><id>iarganda</id></properties>
+		</contributor>
+		<contributor>
+			<name>John Bogovic</name>
+			<url>http://imagej.net/User:Bogovic</url>
+			<properties><id>bogovicj</id></properties>
+		</contributor>
+		<contributor>
+			<name>Olivier Burri</name>
+			<url>http://imagej.net/User:Oburri</url>
+			<properties><id>lacan</id></properties>
+		</contributor>
+		<contributor>
+			<name>Albert Cardona</name>
+			<url>http://imagej.net/User:Albertcardona</url>
+			<properties><id>acardona</id></properties>
+		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>http://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
+		<contributor>
+			<name>Mark Hiner</name>
+			<url>http://imagej.net/User:Hinerm</url>
+			<properties><id>hinerm</id></properties>
+		</contributor>
+		<contributor>
+			<name>Philipp Hanslovsky</name>
+			<properties><id>hanslovsky</id></properties>
+		</contributor>
+		<contributor>
+			<name>Larry Lindsey</name>
+			<url>http://imagej.net/User:Lindsey</url>
+			<properties><id>larrylindsey</id></properties>
+		</contributor>
+		<contributor>
+			<name>Mark Longair</name>
+			<url>http://imagej.net/User:Mark</url>
+			<properties><id>mhl</id></properties>
+		</contributor>
+		<contributor>
+			<name>Eric Perlman</name>
+			<properties><id>perlman</id></properties>
+		</contributor>
+		<contributor>
+			<name>Tobias Pietzsch</name>
+			<url>http://imagej.net/User:Pietzsch</url>
+			<properties><id>tpietzsch</id></properties>
+		</contributor>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>http://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+		<contributor>
+			<name>Johannes Schindelin</name>
+			<url>http://imagej.net/User:Schindelin</url>
+			<properties><id>dscho</id></properties>
+		</contributor>
+	</contributors>
+
 	<modules>
 		<module>mpicbg</module>
 		<module>mpicbg_</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -10,10 +10,6 @@
 		<version>18.1.0</version>
 		<relativePath />
 	</parent>
-
-	<properties>
-		<mpicbg.version>1.1.1</mpicbg.version>
-	</properties>
 
 	<groupId>mpicbg</groupId>
 	<artifactId>pom-mpicbg</artifactId>
@@ -43,6 +39,10 @@
 		<url>http://jenkins.imagej.net/job/MPICBG/</url>
 	</ciManagement>
 
+	<properties>
+		<mpicbg.version>1.1.1</mpicbg.version>
+	</properties>
+
 	<repositories>
 		<!-- NB: for project parent -->
 		<repository>
@@ -60,5 +60,4 @@
 			</modules>
 		</profile>
 	</profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,14 @@
 		<tag>HEAD</tag>
 		<url>https://github.com/axtimwalde/mpicbg</url>
 	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/axtimwalde/mpicbg/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>http://jenkins.imagej.net/job/MPICBG/</url>
+	</ciManagement>
 
 	<repositories>
 		<!-- NB: for project parent -->


### PR DESCRIPTION
These patches clean up the POMs in a couple of ways.

In particular, they add the developers and contributors sections which we are now using to autogenerate wiki pages documenting [team roles](http://imagej.net/Team) for each project.