### PR TITLE
Addresses bug #26

### DIFF
--- a/mpicbg/src/main/java/mpicbg/imagefeatures/FloatArray2DMOPS.java
+++ b/mpicbg/src/main/java/mpicbg/imagefeatures/FloatArray2DMOPS.java
@@ -330,10 +330,16 @@ public class FloatArray2DMOPS extends FloatArray2DFeatureTransform< FloatArray2D
 		//ImageArrayConverter.FloatArrayToImagePlus( gradientROI[ 0 ], "gaussianMaskedGradientROI", 0, 0 ).show();
 		//ImageArrayConverter.FloatArrayToImagePlus( gradientROI[ 1 ], "gaussianMaskedGradientROI", 0, 0 ).show();
 
+		final double TWOPI = 2 * Math.PI;
+
 		// build an orientation histogram of the region
 		for ( int i = 0; i < gradientROI[ 0 ].data.length; ++i )
 		{
-			final int bin = Math.max( 0, ( int )( ( gradientROI[ 1 ].data[ i ] + Math.PI ) / ORIENTATION_BIN_SIZE ) );
+			double angleFraction =  ( gradientROI[ 1 ].data[ i ] + Math.PI ) ;
+			if( angleFraction >= TWOPI )
+				angleFraction -= TWOPI;
+
+			final int bin = Math.max( 0, ( int )( angleFraction / ORIENTATION_BIN_SIZE ));
 			histogram_bins[ bin ] += gradientROI[ 0 ].data[ i ];
 		}
 

--- a/mpicbg/src/main/java/mpicbg/imagefeatures/FloatArray2DMOPS.java
+++ b/mpicbg/src/main/java/mpicbg/imagefeatures/FloatArray2DMOPS.java
@@ -279,6 +279,7 @@ public class FloatArray2DMOPS extends FloatArray2DFeatureTransform< FloatArray2D
 			final List< Feature > features )
 	{
 		final int ORIENTATION_BINS = 36;
+		final int ORIENTATION_BINS1 = ORIENTATION_BINS - 1;
 		final double ORIENTATION_BIN_SIZE = 2.0 * Math.PI / ORIENTATION_BINS;
 		final float[] histogram_bins = new float[ ORIENTATION_BINS ];
 
@@ -330,16 +331,10 @@ public class FloatArray2DMOPS extends FloatArray2DFeatureTransform< FloatArray2D
 		//ImageArrayConverter.FloatArrayToImagePlus( gradientROI[ 0 ], "gaussianMaskedGradientROI", 0, 0 ).show();
 		//ImageArrayConverter.FloatArrayToImagePlus( gradientROI[ 1 ], "gaussianMaskedGradientROI", 0, 0 ).show();
 
-		final double TWOPI = 2 * Math.PI;
-
 		// build an orientation histogram of the region
 		for ( int i = 0; i < gradientROI[ 0 ].data.length; ++i )
 		{
-			double angleFraction =  ( gradientROI[ 1 ].data[ i ] + Math.PI ) ;
-			if( angleFraction >= TWOPI )
-				angleFraction -= TWOPI;
-
-			final int bin = Math.max( 0, ( int )( angleFraction / ORIENTATION_BIN_SIZE ));
+			final int bin = Math.max( 0, Math.min( ORIENTATION_BINS1, ( int )( ( gradientROI[ 1 ].data[ i ] + Math.PI ) / ORIENTATION_BIN_SIZE ) ) );
 			histogram_bins[ bin ] += gradientROI[ 0 ].data[ i ];
 		}
 


### PR DESCRIPTION
Avoids a round error by checking that the orientation is within expected
bounds.  If not, wraps the result into lower bins.