### PR TITLE
Use imagej.net URL for all developers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,7 @@
 		<developer>
 			<id>axtimwalde</id>
 			<name>Stephan Saalfeld</name>
-			<email>saalfelds@janelia.hhmi.org</email>
-			<url>http://www.janelia.org/lab/saalfeld-lab</url>
-			<organization>HHMI Janelia Research Campus</organization>
-			<organizationUrl>http://www.janelia.org/</organizationUrl>
+			<url>http://imagej.net/User:Saalfeld</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>
@@ -36,13 +33,12 @@
 				<role>support</role>
 				<role>maintainer</role>
 			</roles>
-			<timezone>-5</timezone>
 		</developer>
 	</developers>
 	<contributors>
 		<contributor>
 			<name>Stephan Preibisch</name>
-			<url>http://imagej.net/User:Preibisch</url>
+			<url>http://imagej.net/User:StephanP</url>
 			<properties><id>StephanPreibisch</id></properties>
 		</contributor>
 		<contributor>


### PR DESCRIPTION
And remove the other info, which is prone to obsolescence.

This information is available from the imagej.net user profile, in an indirect way which can be updated in case it changes, rather than being baked into the POM forever.

This change will make automatic generation of informational sidebars on the wiki easier to accomplish.