### PR TITLE
fix bug that prevents the pre-alignment if matches == minNumMatches

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/TileConfiguration.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileConfiguration.java
@@ -506,7 +506,7 @@ A:				for ( final Tile< ? > t : tiles )
 					final ArrayList< PointMatch > pm = getConnectingPointMatches( targetTile, referenceTile );
 
 					// are there enough matches?
-					if ( pm.size() > targetTile.getModel().getMinNumMatches() )
+					if ( pm.size() >= targetTile.getModel().getMinNumMatches() )
 					{
 						// fit the model of the targetTile to the subset of matches
 						// mapping its local coordinates target.p.l into the world


### PR DESCRIPTION
the test has to be >= instead of >, it should still do if the number of matches == minNumMatches, and not only if it is more
