### PR TITLE
Implement proper copy() method for ConstantModels

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/ConstantAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/ConstantAffineModel1D.java
@@ -37,6 +37,14 @@ final public class ConstantAffineModel1D< A extends Model< A > & Affine1D< A > &
 	}
 
 	@Override
+	public ConstantAffineModel1D< A > copy()
+	{
+		final ConstantAffineModel1D< A > copy = new ConstantAffineModel1D< A >( model.copy() );
+		copy.cost = cost;
+		return copy;
+	}
+
+	@Override
 	public ConstantAffineModel1D< A > createInverse()
 	{
 		final ConstantAffineModel1D< A > inverse = new ConstantAffineModel1D< A >( model.createInverse() );

--- a/mpicbg/src/main/java/mpicbg/models/InvertibleConstantModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/InvertibleConstantModel.java
@@ -34,6 +34,15 @@ public class InvertibleConstantModel<
 	}
 
 	@Override
+	public M copy()
+	{
+		@SuppressWarnings( "unchecked" )
+		final M copy = ( M )new InvertibleConstantModel< A, M >( model.copy() );
+		copy.cost = cost;
+		return copy;
+	}
+
+	@Override
 	public double[] applyInverse( final double[] location ) throws NoninvertibleModelException
 	{
 		final double[] copy = location.clone();


### PR DESCRIPTION
Fixes the `ClassCastException` within the `filter()` call using the following model setup:
`InterpolatedAffineModel1D< A, ConstantAffineModel1D< B > >`