### PR TITLE
Update to pom-scijava parent, and switch to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+jdk: oraclejdk8
+branches:
+  only: master
+install: true
+script: ".travis/build.sh"
+after_success: ".travis/notify.sh Travis-Success"
+after_failure: ".travis/notify.sh Travis-Failure"
+env:
+  global:
+  - secure: JArYaTnPw9bJbfoQ650a9ScQ14O/6KneUAu+jBARy9nvNLNOTO8dv70Z7BwKHolc7ItERIwLHVJkdr1/frklppFc3uJo1Xb/sjAavmL7ValGyJ/g+/+b/bNwRLHor/WIVSGVFjGg4lnZLPrU1qxUsgkqNOt7jyjROQh/0tnXlEM=
+  - secure: NesO0ghUMmT56w7yf3nqcUlsd7Myv0bRqV3L4dsFpP9Eu4J1sb1UgAfO+cr7DSUHSWCrbfwxQiAKCkuGWRezpFGcRVdkpzftDKXkI+odsUzNJt2UcHtP6EGQPxf/aLc2dTvtrmFXjCVlZg17FOxvEs5IIz4WO6zJjVFlmD0vLnc=

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+dir="$(dirname "$0")"
+test "$TRAVIS_SECURE_ENV_VARS" = true \
+  -a "$TRAVIS_PULL_REQUEST" = false \
+  -a "$TRAVIS_BRANCH" = master &&
+  mvn -Pdeploy-to-imagej deploy --settings "$dir/settings.xml" ||
+  mvn install

--- a/.travis/notify.sh
+++ b/.travis/notify.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+curl -fs "https://jenkins.imagej.net/job/$1/buildWithParameters?token=$TOKEN_NAME&repo=$TRAVIS_REPO_SLUG&commit=$TRAVIS_COMMIT&pr=$TRAVIS_PULL_REQUEST"

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+  <servers>
+    <server>
+      <id>imagej.releases</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+    <server>
+      <id>imagej.snapshots</id>
+      <username>travis</username>
+      <password>${env.MAVEN_PASS}</password>
+    </server>
+  </servers>
+</settings>

--- a/mpicbg/pom.xml
+++ b/mpicbg/pom.xml
@@ -138,8 +138,8 @@
 		<url>https://github.com/axtimwalde/mpicbg/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/MPICBG/</url>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/axtimwalde/mpicbg</url>
 	</ciManagement>
 
 	<properties>

--- a/mpicbg/pom.xml
+++ b/mpicbg/pom.xml
@@ -10,11 +10,142 @@
 		<version>1.1.2-SNAPSHOT</version>
 	</parent>
 
-	<!-- <properties> <enforcer.skip>true</enforcer.skip> </properties> -->
 	<artifactId>mpicbg</artifactId>
 
-	<name>jars/mpicbg.jar</name>
-	<description></description>
+	<name>MPICBG Core Library</name>
+	<description>MPICBG Core Library.</description>
+	<url>https://github.com/axtimwalde/mpicbg</url>
+	<inceptionYear>2008</inceptionYear>
+	<organization>
+		<name>Fiji</name>
+		<url>https://fiji.sc/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU General Public License v2+</name>
+			<url>https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<id>axtimwalde</id>
+			<name>Stephan Saalfeld</name>
+			<url>https://imagej.net/User:Saalfeld</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Stephan Preibisch</name>
+			<url>https://imagej.net/User:StephanP</url>
+			<properties><id>StephanPreibisch</id></properties>
+		</contributor>
+		<contributor>
+			<name>Ignacio Arganda-Carreras</name>
+			<url>https://imagej.net/User:Iarganda</url>
+			<properties><id>iarganda</id></properties>
+		</contributor>
+		<contributor>
+			<name>John Bogovic</name>
+			<url>https://imagej.net/User:Bogovic</url>
+			<properties><id>bogovicj</id></properties>
+		</contributor>
+		<contributor>
+			<name>Olivier Burri</name>
+			<url>https://imagej.net/User:Oburri</url>
+			<properties><id>lacan</id></properties>
+		</contributor>
+		<contributor>
+			<name>Albert Cardona</name>
+			<url>https://imagej.net/User:Albertcardona</url>
+			<properties><id>acardona</id></properties>
+		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>https://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
+		<contributor>
+			<name>Philipp Hanslovsky</name>
+			<url>https://imagej.net/User:Hanslovsky</url>
+			<properties><id>hanslovsky</id></properties>
+		</contributor>
+		<contributor>
+			<name>Mark Hiner</name>
+			<url>https://imagej.net/User:Hinerm</url>
+			<properties><id>hinerm</id></properties>
+		</contributor>
+		<contributor>
+			<name>Larry Lindsey</name>
+			<url>https://imagej.net/User:Lindsey</url>
+			<properties><id>larrylindsey</id></properties>
+		</contributor>
+		<contributor>
+			<name>Mark Longair</name>
+			<url>https://imagej.net/User:Mark</url>
+			<properties><id>mhl</id></properties>
+		</contributor>
+		<contributor>
+			<name>Eric Perlman</name>
+			<properties><id>perlman</id></properties>
+		</contributor>
+		<contributor>
+			<name>Tobias Pietzsch</name>
+			<url>https://imagej.net/User:Pietzsch</url>
+			<properties><id>tpietzsch</id></properties>
+		</contributor>
+		<contributor>
+			<name>Igor Pisarev</name>
+			<properties><id>igorpisarev</id></properties>
+		</contributor>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>https://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+		<contributor>
+			<name>Johannes Schindelin</name>
+			<url>https://imagej.net/User:Schindelin</url>
+			<properties><id>dscho</id></properties>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/axtimwalde/mpicbg</connection>
+		<developerConnection>scm:git:git@github.com:axtimwalde/mpicbg</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/axtimwalde/mpicbg</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/axtimwalde/mpicbg/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>http://jenkins.imagej.net/job/MPICBG/</url>
+	</ciManagement>
+
+	<properties>
+		<license.licenseName>gpl_v2</license.licenseName>
+		<license.copyrightOwners>Stephan Saalfeld et. al.</license.copyrightOwners>
+	</properties>
 
 	<dependencies>
 		<!-- ImageJ dependencies -->

--- a/mpicbg_/pom.xml
+++ b/mpicbg_/pom.xml
@@ -12,10 +12,98 @@
 
 	<artifactId>mpicbg_</artifactId>
 
-	<name>plugins/mpicbg_.jar</name>
-	<description></description>
+	<name>MPICBG plugin for Fiji</name>
+	<description>MPICBG plugin for Fiji.</description>
+	<url>https://github.com/axtimwalde/mpicbg</url>
+	<inceptionYear>2008</inceptionYear>
+	<organization>
+		<name>Fiji</name>
+		<url>https://fiji.sc/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU General Public License v2+</name>
+			<url>https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
-	<!-- <properties> <enforcer.skip>true</enforcer.skip> </properties> -->
+	<developers>
+		<developer>
+			<id>axtimwalde</id>
+			<name>Stephan Saalfeld</name>
+			<url>https://imagej.net/User:Saalfeld</url>
+			<roles>
+				<role>founder</role>
+				<role>lead</role>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+		</developer>
+	</developers>
+	<contributors>
+		<contributor>
+			<name>Olivier Burri</name>
+			<url>https://imagej.net/User:Oburri</url>
+			<properties><id>lacan</id></properties>
+		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>https://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
+		<contributor>
+			<name>Mark Hiner</name>
+			<url>https://imagej.net/User:Hinerm</url>
+			<properties><id>hinerm</id></properties>
+		</contributor>
+		<contributor>
+			<name>Stephan Preibisch</name>
+			<url>https://imagej.net/User:StephanP</url>
+			<properties><id>StephanPreibisch</id></properties>
+		</contributor>
+		<contributor>
+			<name>Curtis Rueden</name>
+			<url>https://imagej.net/User:Rueden</url>
+			<properties><id>ctrueden</id></properties>
+		</contributor>
+		<contributor>
+			<name>Johannes Schindelin</name>
+			<url>https://imagej.net/User:Schindelin</url>
+			<properties><id>dscho</id></properties>
+		</contributor>
+	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
+
+	<scm>
+		<connection>scm:git:git://github.com/axtimwalde/mpicbg</connection>
+		<developerConnection>scm:git:git@github.com:axtimwalde/mpicbg</developerConnection>
+		<tag>HEAD</tag>
+		<url>https://github.com/axtimwalde/mpicbg</url>
+	</scm>
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/axtimwalde/mpicbg/issues</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>http://jenkins.imagej.net/job/MPICBG/</url>
+	</ciManagement>
+
+	<properties>
+		<license.licenseName>gpl_v2</license.licenseName>
+		<license.copyrightOwners>Stephan Saalfeld et. al.</license.copyrightOwners>
+	</properties>
+
 	<dependencies>
 		<!-- Project dependencies -->
 		<dependency>

--- a/mpicbg_/pom.xml
+++ b/mpicbg_/pom.xml
@@ -95,8 +95,8 @@
 		<url>https://github.com/axtimwalde/mpicbg/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/MPICBG/</url>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/axtimwalde/mpicbg</url>
 	</ciManagement>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>sc.fiji</groupId>
-		<artifactId>pom-fiji</artifactId>
-		<version>18.1.0</version>
+		<groupId>org.scijava</groupId>
+		<artifactId>pom-scijava</artifactId>
+		<version>14.0.0</version>
 		<relativePath />
 	</parent>
 
@@ -17,13 +17,26 @@
 	<packaging>pom</packaging>
 
 	<name>Aggregator project for Stephan Saalfeld's mpicbg library and plugin collection</name>
-	<description></description>
+	<description>Aggregator project for Stephan Saalfeld's mpicbg library and plugin collection plugin for Fiji.</description>
+	<url>https://github.com/axtimwalde/mpicbg</url>
+	<inceptionYear>2008</inceptionYear>
+	<organization>
+		<name>Fiji</name>
+		<url>https://fiji.sc/</url>
+	</organization>
+	<licenses>
+		<license>
+			<name>GNU General Public License v2+</name>
+			<url>https://www.gnu.org/licenses/old-licenses/gpl-2.0.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
 
 	<developers>
 		<developer>
 			<id>axtimwalde</id>
 			<name>Stephan Saalfeld</name>
-			<url>http://imagej.net/User:Saalfeld</url>
+			<url>https://imagej.net/User:Saalfeld</url>
 			<roles>
 				<role>founder</role>
 				<role>lead</role>
@@ -37,74 +50,28 @@
 	</developers>
 	<contributors>
 		<contributor>
-			<name>Stephan Preibisch</name>
-			<url>http://imagej.net/User:StephanP</url>
-			<properties><id>StephanPreibisch</id></properties>
-		</contributor>
-		<contributor>
-			<name>Ignacio Arganda-Carreras</name>
-			<url>http://imagej.net/User:Iarganda</url>
-			<properties><id>iarganda</id></properties>
-		</contributor>
-		<contributor>
-			<name>John Bogovic</name>
-			<url>http://imagej.net/User:Bogovic</url>
-			<properties><id>bogovicj</id></properties>
-		</contributor>
-		<contributor>
-			<name>Olivier Burri</name>
-			<url>http://imagej.net/User:Oburri</url>
-			<properties><id>lacan</id></properties>
-		</contributor>
-		<contributor>
-			<name>Albert Cardona</name>
-			<url>http://imagej.net/User:Albertcardona</url>
-			<properties><id>acardona</id></properties>
-		</contributor>
-		<contributor>
-			<name>Jan Eglinger</name>
-			<url>http://imagej.net/User:Eglinger</url>
-			<properties><id>imagejan</id></properties>
-		</contributor>
-		<contributor>
 			<name>Mark Hiner</name>
-			<url>http://imagej.net/User:Hinerm</url>
+			<url>https://imagej.net/User:Hinerm</url>
 			<properties><id>hinerm</id></properties>
 		</contributor>
 		<contributor>
-			<name>Philipp Hanslovsky</name>
-			<properties><id>hanslovsky</id></properties>
-		</contributor>
-		<contributor>
-			<name>Larry Lindsey</name>
-			<url>http://imagej.net/User:Lindsey</url>
-			<properties><id>larrylindsey</id></properties>
-		</contributor>
-		<contributor>
-			<name>Mark Longair</name>
-			<url>http://imagej.net/User:Mark</url>
-			<properties><id>mhl</id></properties>
-		</contributor>
-		<contributor>
-			<name>Eric Perlman</name>
-			<properties><id>perlman</id></properties>
-		</contributor>
-		<contributor>
-			<name>Tobias Pietzsch</name>
-			<url>http://imagej.net/User:Pietzsch</url>
-			<properties><id>tpietzsch</id></properties>
-		</contributor>
-		<contributor>
 			<name>Curtis Rueden</name>
-			<url>http://imagej.net/User:Rueden</url>
+			<url>https://imagej.net/User:Rueden</url>
 			<properties><id>ctrueden</id></properties>
 		</contributor>
 		<contributor>
 			<name>Johannes Schindelin</name>
-			<url>http://imagej.net/User:Schindelin</url>
+			<url>https://imagej.net/User:Schindelin</url>
 			<properties><id>dscho</id></properties>
 		</contributor>
 	</contributors>
+
+	<mailingLists>
+		<mailingList>
+			<name>ImageJ Forum</name>
+			<archive>http://forum.imagej.net/</archive>
+		</mailingList>
+	</mailingLists>
 
 	<modules>
 		<module>mpicbg</module>
@@ -127,13 +94,15 @@
 	</ciManagement>
 
 	<properties>
+		<license.licenseName>gpl_v2</license.licenseName>
+		<license.copyrightOwners>Stephan Saalfeld et. al.</license.copyrightOwners>
 		<mpicbg.version>1.1.1</mpicbg.version>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<url>https://maven.imagej.net/content/groups/public</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,8 +89,8 @@
 		<url>https://github.com/axtimwalde/mpicbg/issues</url>
 	</issueManagement>
 	<ciManagement>
-		<system>Jenkins</system>
-		<url>http://jenkins.imagej.net/job/MPICBG/</url>
+		<system>Travis CI</system>
+		<url>https://travis-ci.org/axtimwalde/mpicbg</url>
 	</ciManagement>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,6 @@
 	</properties>
 
 	<repositories>
-		<!-- NB: for project parent -->
 		<repository>
 			<id>imagej.public</id>
 			<url>http://maven.imagej.net/content/groups/public</url>


### PR DESCRIPTION
This also updates the contributors metadata for each module as well as the aggregator to be correct for each respective scope.

It is in some ways suboptimal that certain metadata blocks must be duplicated. However, the require-elements enforcer rule is not currently smart enough to deal with multi-module builds. And I do not know whether I would want it to support ignoring certain elements in this case anyway, since it makes it harder for downstream tooling to consume each individual POM.

Note that to fully switch to Travis, you will need to visit https://travis-ci.org/axtimwalde/mpicbg and enable the repository there.