### PR TITLE
Allow changing tile model after initialization

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/Tile.java
+++ b/mpicbg/src/main/java/mpicbg/models/Tile.java
@@ -44,7 +44,6 @@ public class Tile< M extends Model< M > > implements Serializable
 	final public void setModel( final M model )
 	{
 		this.model = model;
-		update();
 	}
 
 	/**

--- a/mpicbg/src/main/java/mpicbg/models/Tile.java
+++ b/mpicbg/src/main/java/mpicbg/models/Tile.java
@@ -38,8 +38,14 @@ public class Tile< M extends Model< M > > implements Serializable
 	 * {@link Point Points} in the {@link Tile} share (and thus determine)
 	 * this common {@link AbstractModel}.
 	 */
-	final protected M model;
+	protected M model;
 	final public M getModel() { return model; }
+
+	final public void setModel( final M model )
+	{
+		this.model = model;
+		update();
+	}
 
 	/**
 	 * A set of point correspondences with {@link PointMatch#getP1() p1} being


### PR DESCRIPTION
Useful when it's needed to pre-align the tiles using one model and then actually fit using a different model.