### PR TITLE
Better set() methods for models

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
@@ -283,6 +283,12 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 	}
 
 	@Override
+	final public void reset()
+	{
+		set( new AffineModel1D() );
+	}
+
+	@Override
 	public AffineModel1D copy()
 	{
 		final AffineModel1D m = new AffineModel1D();

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
@@ -288,6 +288,14 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 		set( new AffineModel1D() );
 	}
 
+	final public void set( final TranslationModel1D m )
+	{
+		reset();
+		m01 = m.t;
+		cost = m.getCost();
+		invert();
+	}
+
 	@Override
 	public AffineModel1D copy()
 	{

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
@@ -374,6 +374,12 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 	}
 
 	@Override
+	final public void reset()
+	{
+		set( new AffineModel2D() );
+	}
+
+	@Override
 	public AffineModel2D copy()
 	{
 		final AffineModel2D m = new AffineModel2D();

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
@@ -379,6 +379,43 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 		set( new AffineModel2D() );
 	}
 
+	final public void set( final TranslationModel2D m )
+	{
+		reset();
+		m02 = m.tx;
+		m12 = m.ty;
+		cost = m.getCost();
+		invert();
+	}
+
+	final public void set( final RigidModel2D m )
+	{
+		final double[][] matrix = new double[ 3 ][ 2 ];
+		m.toMatrix( matrix );
+		m00 = matrix[ 0 ][ 0 ];
+		m01 = matrix[ 0 ][ 1 ];
+		m02 = matrix[ 0 ][ 2 ];
+		m10 = matrix[ 1 ][ 0 ];
+		m11 = matrix[ 1 ][ 1 ];
+		m12 = matrix[ 1 ][ 2 ];
+		cost = m.getCost();
+		invert();
+	}
+
+	final public void set( final SimilarityModel2D m )
+	{
+		final double[][] matrix = new double[ 3 ][ 2 ];
+		m.toMatrix( matrix );
+		m00 = matrix[ 0 ][ 0 ];
+		m01 = matrix[ 0 ][ 1 ];
+		m02 = matrix[ 0 ][ 2 ];
+		m10 = matrix[ 1 ][ 0 ];
+		m11 = matrix[ 1 ][ 1 ];
+		m12 = matrix[ 1 ][ 2 ];
+		cost = m.getCost();
+		invert();
+	}
+
 	@Override
 	public AffineModel2D copy()
 	{

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
@@ -552,6 +552,55 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 		set( new AffineModel3D() );
 	}
 
+	final public void set( final TranslationModel3D m )
+	{
+		reset();
+		final double[] translation = m.getTranslation();
+		m03 = translation[ 0 ];
+		m13 = translation[ 1 ];
+		m23 = translation[ 2 ];
+		cost = m.getCost();
+		invert();
+	}
+
+	final public void set( final RigidModel3D m )
+	{
+		m00 = m.m00;
+		m10 = m.m10;
+		m20 = m.m20;
+		m01 = m.m01;
+		m11 = m.m11;
+		m21 = m.m21;
+		m02 = m.m02;
+		m12 = m.m12;
+		m22 = m.m22;
+		m03 = m.m03;
+		m13 = m.m13;
+		m23 = m.m23;
+
+		cost = m.getCost();
+		invert();
+	}
+
+	final public void set( final SimilarityModel3D m )
+	{
+		m00 = m.m00;
+		m10 = m.m10;
+		m20 = m.m20;
+		m01 = m.m01;
+		m11 = m.m11;
+		m21 = m.m21;
+		m02 = m.m02;
+		m12 = m.m12;
+		m22 = m.m22;
+		m03 = m.m03;
+		m13 = m.m13;
+		m23 = m.m23;
+
+		cost = m.getCost();
+		invert();
+	}
+
 	@Override
 	public AffineModel3D copy()
 	{

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
@@ -547,6 +547,12 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 	}
 
 	@Override
+	final public void reset()
+	{
+		set( new AffineModel3D() );
+	}
+
+	@Override
 	public AffineModel3D copy()
 	{
 		final AffineModel3D m = new AffineModel3D();

--- a/mpicbg/src/main/java/mpicbg/models/ConstantModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/ConstantModel.java
@@ -54,6 +54,9 @@ public class ConstantModel< A extends Model< A >, M extends ConstantModel< A, M 
 	public void set( final M m ) {}
 
 	@Override
+	final public void reset() {}
+
+	@Override
 	public M copy()
 	{
 		@SuppressWarnings( "unchecked" )

--- a/mpicbg/src/main/java/mpicbg/models/HomographyModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/HomographyModel2D.java
@@ -231,6 +231,12 @@ public class HomographyModel2D extends AbstractModel< HomographyModel2D > implem
 	}
 
 	@Override
+	final public void reset()
+	{
+		set( new HomographyModel2D() );
+	}
+
+	@Override
 	public HomographyModel2D copy()
 	{
 		final HomographyModel2D m = new HomographyModel2D();

--- a/mpicbg/src/main/java/mpicbg/models/IdentityModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/IdentityModel.java
@@ -85,6 +85,12 @@ public class IdentityModel extends AbstractModel< IdentityModel > implements
 	}
 
 	@Override
+	final public void reset()
+	{
+		cost = Double.MAX_VALUE;
+	}
+
+	@Override
 	final public void preConcatenate( final IdentityModel m ) {}
 
 	@Override

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -45,7 +45,8 @@ final public class InterpolatedAffineModel1D<
 		interpolate();
 	}
 
-	protected void interpolate()
+	@Override
+	public void interpolate()
 	{
 		a.toArray( afs );
 		b.toArray( bfs );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -71,6 +71,13 @@ final public class InterpolatedAffineModel1D<
 	}
 
 	@Override
+	public void reset()
+	{
+		super.reset();
+		interpolate();
+	}
+
+	@Override
 	public InterpolatedAffineModel1D< A, B > copy()
 	{
 		final InterpolatedAffineModel1D< A, B > copy = new InterpolatedAffineModel1D< A, B >( a.copy(), b.copy(), lambda );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -161,22 +161,6 @@ final public class InterpolatedAffineModel1D<
 		affine.toMatrix( data );
 	}
 
-	/**
-	 * Initialize the model such that the respective affine transform is:
-	 *
-	 * <pre>
-	 * m0 m1
-	 * 0   1
-	 * </pre>
-	 *
-	 * @param m0
-	 * @param m1
-	 */
-	final public void set( final float m0, final float m1 )
-	{
-		affine.set( m0, m1 );
-	}
-
 	@Override
 	public void estimateBounds( final double[] min, final double[] max )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -46,7 +46,8 @@ final public class InterpolatedAffineModel2D<
 		interpolate();
 	}
 
-	protected void interpolate()
+	@Override
+	public void interpolate()
 	{
 		a.toArray( afs );
 		b.toArray( bfs );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -174,39 +174,6 @@ final public class InterpolatedAffineModel2D<
 		affine.toMatrix( data );
 	}
 
-	/**
-	 * Initialize the model such that the respective affine transform is:
-	 *
-	 * <pre>
-	 * m00 m01 m02
-	 * m10 m11 m12
-	 * 0   0   1
-	 * </pre>
-	 *
-	 * @param m00
-	 * @param m10
-	 *
-	 * @param m01
-	 * @param m11
-	 *
-	 * @param m02
-	 * @param m12
-	 */
-	final public void set( final double m00, final double m10, final double m01, final double m11, final double m02, final double m12 )
-	{
-		affine.set( m00, m10, m01, m11, m02, m12 );
-	}
-
-	/**
-	 * Initialize the model with the parameters of an {@link AffineTransform}.
-	 *
-	 * @param a
-	 */
-	final public void set( final AffineTransform a )
-	{
-		affine.set( a );
-	}
-
 	@Override
 	public void estimateBounds( final double[] min, final double[] max )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -72,6 +72,13 @@ final public class InterpolatedAffineModel2D<
 	}
 
 	@Override
+	public void reset()
+	{
+		super.reset();
+		interpolate();
+	}
+
+	@Override
 	public InterpolatedAffineModel2D< A, B > copy()
 	{
 		final InterpolatedAffineModel2D< A, B > copy = new InterpolatedAffineModel2D< A, B >( a.copy(), b.copy(), lambda );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -71,6 +71,13 @@ final public class InterpolatedAffineModel3D<
 	}
 
 	@Override
+	public void reset()
+	{
+		super.reset();
+		interpolate();
+	}
+
+	@Override
 	public InterpolatedAffineModel3D< A, B > copy()
 	{
 		final InterpolatedAffineModel3D< A, B > copy = new InterpolatedAffineModel3D< A, B >( a.copy(), b.copy(), lambda );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -42,7 +42,8 @@ final public class InterpolatedAffineModel3D<
 		interpolate();
 	}
 
-	protected void interpolate()
+	@Override
+	public void interpolate()
 	{
 		a.toArray( afs );
 		b.toArray( bfs );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedModel.java
@@ -87,6 +87,14 @@ public class InterpolatedModel< A extends Model< A >, B extends Model< B >, M ex
 	}
 
 	@Override
+	public void reset()
+	{
+		a.reset();
+		b.reset();
+		cost = Double.MAX_VALUE;
+	}
+
+	@Override
 	public M copy()
 	{
 		@SuppressWarnings( "unchecked" )

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedModel.java
@@ -25,7 +25,7 @@ import java.util.Collection;
  *
  * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
  */
-public class InterpolatedModel< A extends Model< A >, B extends Model< B >, M extends InterpolatedModel< A, B, M > > extends AbstractModel< M >
+public abstract class InterpolatedModel< A extends Model< A >, B extends Model< B >, M extends InterpolatedModel< A, B, M > > extends AbstractModel< M >
 {
 	private static final long serialVersionUID = 6174301903574154605L;
 
@@ -41,6 +41,8 @@ public class InterpolatedModel< A extends Model< A >, B extends Model< B >, M ex
 		this.lambda = lambda;
 		l1 = 1.0 - lambda;
 	}
+
+	public abstract void interpolate();
 
 	public A getA()
 	{
@@ -92,15 +94,6 @@ public class InterpolatedModel< A extends Model< A >, B extends Model< B >, M ex
 		a.reset();
 		b.reset();
 		cost = Double.MAX_VALUE;
-	}
-
-	@Override
-	public M copy()
-	{
-		@SuppressWarnings( "unchecked" )
-		final M copy = ( M )new InterpolatedModel< A, B, M >( a.copy(), b.copy(), lambda );
-		copy.cost = cost;
-		return copy;
 	}
 
 	@Override

--- a/mpicbg/src/main/java/mpicbg/models/InvertibleInterpolatedModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/InvertibleInterpolatedModel.java
@@ -22,7 +22,7 @@ package mpicbg.models;
  *
  * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
  */
-public class InvertibleInterpolatedModel<
+public abstract class InvertibleInterpolatedModel<
 		A extends Model< A > & InvertibleCoordinateTransform,
 		B extends Model< B > & InvertibleCoordinateTransform,
 		M extends InvertibleInterpolatedModel< A, B, M > > extends InterpolatedModel< A, B, M > implements InvertibleCoordinateTransform
@@ -32,15 +32,6 @@ public class InvertibleInterpolatedModel<
 	public InvertibleInterpolatedModel( final A a, final B b, final double lambda )
 	{
 		super( a, b, lambda );
-	}
-
-	@Override
-	public M copy()
-	{
-		@SuppressWarnings( "unchecked" )
-		final M copy = ( M )new InvertibleInterpolatedModel< A, B, M >( a.copy(), b.copy(), lambda );
-		copy.cost = cost;
-		return copy;
 	}
 
 	@Override
@@ -62,14 +53,5 @@ public class InvertibleInterpolatedModel<
 			final double dd = copy[ d ] - point[ d ];
 			point[ d ] += lambda * dd;
 		}
-	}
-
-	@Override
-	public InvertibleCoordinateTransform createInverse()
-	{
-		@SuppressWarnings( "unchecked" )
-		final InvertibleInterpolatedModel< A, B, M > inverse = new InvertibleInterpolatedModel< A, B, M >( ( A )a.createInverse(), ( B )b.createInverse(), lambda );
-		inverse.cost = cost;
-		return inverse;
 	}
 }

--- a/mpicbg/src/main/java/mpicbg/models/Model.java
+++ b/mpicbg/src/main/java/mpicbg/models/Model.java
@@ -401,6 +401,11 @@ public interface Model< M extends Model< M > > extends CoordinateTransform
 	 */
 	public void set( final M m );
 
+	/**
+	 * Reset the model to its default state.
+	 */
+	public void reset();
+
 
 	/**
 	 * Clone the model.

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel2D.java
@@ -361,6 +361,12 @@ public class RigidModel2D extends AbstractAffineModel2D< RigidModel2D >
 		cost = m.cost;
 	}
 
+	@Override
+	final public void reset()
+	{
+		set( new RigidModel2D() );
+	}
+
 	final private void invert()
 	{
 		itx = -sin * ty - cos * tx;

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel2D.java
@@ -367,6 +367,15 @@ public class RigidModel2D extends AbstractAffineModel2D< RigidModel2D >
 		set( new RigidModel2D() );
 	}
 
+	final public void set( final TranslationModel2D m )
+	{
+		reset();
+		tx = m.tx;
+		ty = m.ty;
+		cost = m.getCost();
+		invert();
+	}
+
 	final private void invert()
 	{
 		itx = -sin * ty - cos * tx;

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
@@ -453,7 +453,7 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 	 * @param m22
 	 * @param m23
 	 */
-	final public void set(
+	final private void set(
 			final double m00, final double m01, final double m02, final double m03,
 			final double m10, final double m11, final double m12, final double m13,
 			final double m20, final double m21, final double m22, final double m23 )

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
@@ -266,6 +266,12 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 	}
 
 	@Override
+	final public void reset()
+	{
+		set( new RigidModel3D() );
+	}
+
+	@Override
 	public RigidModel3D copy()
 	{
 		final RigidModel3D m = new RigidModel3D();

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
@@ -271,6 +271,17 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 		set( new RigidModel3D() );
 	}
 
+	final public void set( final TranslationModel3D m )
+	{
+		reset();
+		final double[] translation = m.getTranslation();
+		m03 = translation[ 0 ];
+		m13 = translation[ 1 ];
+		m23 = translation[ 2 ];
+		cost = m.getCost();
+		invert();
+	}
+
 	@Override
 	public RigidModel3D copy()
 	{

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel2D.java
@@ -377,6 +377,12 @@ public class SimilarityModel2D extends AbstractAffineModel2D< SimilarityModel2D 
 		cost = m.cost;
 	}
 
+	@Override
+	final public void reset()
+	{
+		set( new SimilarityModel2D() );
+	}
+
 	final protected void invert()
 	{
 		final double det = scos * scos + ssin * ssin;

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel2D.java
@@ -383,6 +383,25 @@ public class SimilarityModel2D extends AbstractAffineModel2D< SimilarityModel2D 
 		set( new SimilarityModel2D() );
 	}
 
+	final public void set( final TranslationModel2D m )
+	{
+		reset();
+		tx = m.tx;
+		ty = m.ty;
+		cost = m.getCost();
+		invert();
+	}
+
+	final public void set( final RigidModel2D m )
+	{
+		scos = m.cos;
+		ssin = m.sin;
+		tx = m.tx;
+		ty = m.ty;
+		cost = m.getCost();
+		invert();
+	}
+
 	final protected void invert()
 	{
 		final double det = scos * scos + ssin * ssin;

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
@@ -410,6 +410,12 @@ public class SimilarityModel3D extends AbstractAffineModel3D< SimilarityModel3D 
 	}
 
 	@Override
+	final public void reset()
+	{
+		set( new SimilarityModel3D() );
+	}
+
+	@Override
 	public SimilarityModel3D copy()
 	{
 		SimilarityModel3D m = new SimilarityModel3D();

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
@@ -415,6 +415,36 @@ public class SimilarityModel3D extends AbstractAffineModel3D< SimilarityModel3D 
 		set( new SimilarityModel3D() );
 	}
 
+	final public void set( final TranslationModel3D m )
+	{
+		reset();
+		final double[] translation = m.getTranslation();
+		m03 = translation[ 0 ];
+		m13 = translation[ 1 ];
+		m23 = translation[ 2 ];
+		cost = m.getCost();
+		invert();
+	}
+
+	final public void set( final RigidModel3D m )
+	{
+		m00 = m.m00;
+		m10 = m.m10;
+		m20 = m.m20;
+		m01 = m.m01;
+		m11 = m.m11;
+		m21 = m.m21;
+		m02 = m.m02;
+		m12 = m.m12;
+		m22 = m.m22;
+		m03 = m.m03;
+		m13 = m.m13;
+		m23 = m.m23;
+
+		cost = m.getCost();
+		invert();
+	}
+
 	@Override
 	public SimilarityModel3D copy()
 	{

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel1D.java
@@ -202,6 +202,13 @@ public class TranslationModel1D extends AbstractAffineModel1D< TranslationModel1
 	}
 
 	@Override
+	final public void reset()
+	{
+		t = 0;
+		cost = Double.MAX_VALUE;
+	}
+
+	@Override
 	final public void preConcatenate( final TranslationModel1D m )
 	{
 		t += m.t;

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
@@ -32,6 +32,8 @@ public class TranslationModel2D extends AbstractAffineModel2D< TranslationModel2
 
 	protected double tx = 0, ty = 0;
 
+	final public double[] getTranslation(){ return new double[] { tx, ty }; }
+
 	@Override
 	final public int getMinNumMatches(){ return MIN_NUM_MATCHES; }
 

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
@@ -231,6 +231,13 @@ public class TranslationModel2D extends AbstractAffineModel2D< TranslationModel2
 	}
 
 	@Override
+	final public void reset()
+	{
+		tx = ty = 0;
+		cost = Double.MAX_VALUE;
+	}
+
+	@Override
 	final public void preConcatenate( final TranslationModel2D m )
 	{
 		tx += m.tx;

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel3D.java
@@ -16,6 +16,7 @@
  */
 package mpicbg.models;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -135,6 +136,13 @@ public class TranslationModel3D extends AbstractAffineModel3D< TranslationModel3
 		translation[ 1 ] = m.translation[ 1 ];
 		translation[ 2 ] = m.translation[ 2 ];
 		cost = m.getCost();
+	}
+
+	@Override
+	final public void reset()
+	{
+		Arrays.fill( translation, 0 );
+		cost = Double.MAX_VALUE;
 	}
 
 	@Override


### PR DESCRIPTION
* For each model type, add `set()` methods that take a more restricted model as an input (for example, `SimilarityModel3D` now can also be initialized with `TranslationModel3D` and `RigidModel3D`)
* Add `reset()` method which sets the model to identity
* Make `interpolate()` an abstract method of `InterpolatedModel`. This is to allow initializing the interpolated models properly (the caller can use the above `set()` methods for `A` and `B` and then call `interpolate()` to ensure consistency).