### PR TITLE
Make interpolate() method public

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -45,7 +45,7 @@ final public class InterpolatedAffineModel1D<
 		interpolate();
 	}
 
-	protected void interpolate()
+	public void interpolate()
 	{
 		a.toArray( afs );
 		b.toArray( bfs );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -46,7 +46,7 @@ final public class InterpolatedAffineModel2D<
 		interpolate();
 	}
 
-	protected void interpolate()
+	public void interpolate()
 	{
 		a.toArray( afs );
 		b.toArray( bfs );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -42,7 +42,7 @@ final public class InterpolatedAffineModel3D<
 		interpolate();
 	}
 
-	protected void interpolate()
+	public void interpolate()
 	{
 		a.toArray( afs );
 		b.toArray( bfs );


### PR DESCRIPTION
A small change that I initially included in #42 but then accidentally reverted.
This essentially allows the caller to ensure that the resulting interpolated affine model is consistent after some of its components have been changed.