### PR TITLE
More robust detection of ill-defined point sets

### DIFF
--- a/mpicbg/pom.xml
+++ b/mpicbg/pom.xml
@@ -157,5 +157,12 @@
 			<groupId>gov.nist.math</groupId>
 			<artifactId>jama</artifactId>
 		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
@@ -18,6 +18,8 @@ package mpicbg.models;
 
 import java.util.Collection;
 
+import mpicbg.util.Util;
+
 /**
  *
  * @author Stephan Saalfeld <saalfelds@janelia.hhmi.org>
@@ -27,6 +29,8 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 	private static final long serialVersionUID = -6691788501310913119L;
 
 	static final protected int MIN_NUM_MATCHES = 2;
+
+	static final protected double EPSILON = 1e-4;
 
 	protected double
 		m00 = 1.0, m01 = 0.0;
@@ -143,7 +147,7 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 			b += wwpx * qx;
 		}
 
-		if ( a == 0 )
+		if ( Util.isApproxEqual( a, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		m00 = b / a;
@@ -207,7 +211,7 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 			b += wwpx * qx;
 		}
 
-		if ( a == 0 )
+		if ( Util.isApproxEqual( a, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		m00 = b / a;
@@ -262,7 +266,7 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 			b += wwpx * qx;
 		}
 
-		if ( a == 0 )
+		if ( Util.isApproxEqual( a, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		m00 = b / a;
@@ -308,7 +312,7 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 
 	protected void invert()
 	{
-		if ( m00 == 0 )
+		if ( Util.isApproxEqual( m00, 0, EPSILON ) )
 		{
 			isInvertible = false;
 			return;

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
@@ -19,6 +19,8 @@ package mpicbg.models;
 import java.awt.geom.AffineTransform;
 import java.util.Collection;
 
+import mpicbg.util.Util;
+
 /**
  * 2d-affine transformation models to be applied to points in 2d-space.
  * This model includes the closed form weighted least squares solution as
@@ -47,6 +49,8 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 	private static final long serialVersionUID = 2323673888015396528L;
 
 	static final protected int MIN_NUM_MATCHES = 3;
+
+	static final protected double EPSILON = 1e-4;
 
 	protected double m00 = 1.0, m10 = 0.0, m01 = 0.0, m11 = 1.0, m02 = 0.0, m12 = 0.0;
 	protected double i00 = 1.0, i10 = 0.0, i01 = 0.0, i11 = 1.0, i02 = 0.0, i12 = 0.0;
@@ -183,7 +187,7 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 
 		final double det = a00 * a11 - a01 * a01;
 
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		m00 = ( a11 * b00 - a01 * b10 ) / det;
@@ -273,7 +277,7 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 
 		final double det = a00 * a11 - a01 * a01;
 
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		m00 = ( a11 * b00 - a01 * b10 ) / det;
@@ -343,7 +347,7 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 
 		final double det = a00 * a11 - a01 * a01;
 
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		m00 = ( a11 * b00 - a01 * b10 ) / det;
@@ -436,7 +440,7 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 	final protected void invert()
 	{
 		final double det = m00 * m11 - m01 * m10;
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 		{
 			isInvertible = false;
 			return;

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
@@ -19,6 +19,7 @@ package mpicbg.models;
 import java.util.Collection;
 
 import mpicbg.util.Matrix3x3;
+import mpicbg.util.Util;
 
 /**
  * 3d-affine transformation models to be applied to points in 3d-space.
@@ -49,6 +50,8 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 	private static final long serialVersionUID = 4591403097787254013L;
 
 	static final protected int MIN_NUM_MATCHES = 4;
+
+	static final protected double EPSILON = 1e-4;
 
 	protected double
 		m00 = 1.0, m01 = 0.0, m02 = 0.0, m03 = 0.0,
@@ -244,7 +247,7 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 			a12 * a12 * a00 -
 			a22 * a01 * a01;
 
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		final double idet = 1.0 / det;
@@ -381,7 +384,7 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 			a12 * a12 * a00 -
 			a22 * a01 * a01;
 
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		final double idet = 1.0 / det;
@@ -494,7 +497,7 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 			a12 * a12 * a00 -
 			a22 * a01 * a01;
 
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 			throw new IllDefinedDataPointsException();
 
 		final double idet = 1.0 / det;
@@ -635,7 +638,7 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 	protected void invert()
 	{
 		final double det = Matrix3x3.det( m00, m01, m02, m10, m11, m12, m20, m21, m22 );
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 		{
 			isInvertible = false;
 			return;

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import mpicbg.util.Matrix3x3;
 import Jama.EigenvalueDecomposition;
 import Jama.Matrix;
+import mpicbg.util.Util;
 
 /**
  *
@@ -33,6 +34,8 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 	private static final long serialVersionUID = 4703083104338949996L;
 
 	static final protected int MIN_NUM_MATCHES = 3;
+
+	static final protected double EPSILON = 1e-4;
 
 	protected double
 	m00 = 1.0, m01 = 0.0, m02 = 0.0, m03 = 0.0,
@@ -316,7 +319,7 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 	protected void invert()
 	{
 		final double det = Matrix3x3.det( m00, m01, m02, m10, m11, m12, m20, m21, m22 );
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 		{
 			isInvertible = false;
 			return;

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
@@ -9,6 +9,7 @@ import mpicbg.models.IllDefinedDataPointsException;
 import mpicbg.models.NotEnoughDataPointsException;
 import mpicbg.models.PointMatch;
 import mpicbg.util.Matrix3x3;
+import mpicbg.util.Util;
 
 /**
  * 3d-rigid transformation models to be applied to points in 3d-space.
@@ -30,6 +31,8 @@ public class SimilarityModel3D extends AbstractAffineModel3D< SimilarityModel3D 
 
 	static final protected int MIN_NUM_MATCHES = 3;
 	
+	static final protected double EPSILON = 1e-4;
+
 	protected double
 		m00 = 1.0, m01 = 0.0, m02 = 0.0, m03 = 0.0, 
 		m10 = 0.0, m11 = 1.0, m12 = 0.0, m13 = 0.0, 
@@ -510,7 +513,7 @@ public class SimilarityModel3D extends AbstractAffineModel3D< SimilarityModel3D 
 	protected void invert()
 	{
 		final double det = Matrix3x3.det( m00, m01, m02, m10, m11, m12, m20, m21, m22 );
-		if ( det == 0 )
+		if ( Util.isApproxEqual( det, 0, EPSILON ) )
 		{
 			isInvertible = false;
 			return;

--- a/mpicbg/src/main/java/mpicbg/util/Util.java
+++ b/mpicbg/src/main/java/mpicbg/util/Util.java
@@ -365,4 +365,40 @@ final public class Util
 	    for ( int i = 1; i < len; i += i )
 	        System.arraycopy( array, 0, array, i, ( ( len - i ) < i ) ? ( len - i ) : i );
 	}
+
+	/**
+	 * Checks if two real values are approximately equal.
+	 *
+	 * @param a
+	 * @param b
+	 * @param threshold
+	 * @return
+	 */
+	final public static boolean isApproxEqual( final float a, final float b, final float threshold )
+	{
+		if ( a == b )
+			return true;
+		else if ( a + threshold > b && a - threshold < b )
+			return true;
+		else
+			return false;
+	}
+
+	/**
+	 * Checks if two real values are approximately equal.
+	 *
+	 * @param a
+	 * @param b
+	 * @param threshold
+	 * @return
+	 */
+	final public static boolean isApproxEqual( final double a, final double b, final double threshold )
+	{
+		if ( a == b )
+			return true;
+		else if ( a + threshold > b && a - threshold < b )
+			return true;
+		else
+			return false;
+	}
 }

--- a/mpicbg/src/test/java/mpicbg/models/IllDefinedConfigurationTest.java
+++ b/mpicbg/src/test/java/mpicbg/models/IllDefinedConfigurationTest.java
@@ -1,0 +1,78 @@
+/**
+ * License: GPL
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License 2
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package mpicbg.models;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+* @author Igor Pisarev
+*/
+public class IllDefinedConfigurationTest
+{
+	@Test( expected = IllDefinedDataPointsException.class )
+	public void testIllDefined() throws NotEnoughDataPointsException, IllDefinedDataPointsException
+	{
+		final List< PointMatch > pointMatches = new ArrayList< PointMatch >();
+		pointMatches.add( new PointMatch( new Point( new double[] { 11391.245522, -9557.644515, 3214.912133 } ), new Point( new double[] { 2334.168005583636, 3518.967770862933, 107.03217906932194 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 11070.939867, -8226.053258, 3213.153702 } ), new Point( new double[] { 2015.8052608873058, 4847.946467837462, 117.1739487701094 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 11070.928153, -8891.92001, 3213.146659 } ), new Point( new double[] { 2013.7415143287162, 4180.5686283211535, 114.917495945355 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 11391.257236, -8891.777763, 3214.919176 } ), new Point( new double[] { 2335.582386241431, 4185.54358979955, 111.22513943121862 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 11711.574604, -9557.502269, 3216.68465 } ), new Point( new double[] { 2652.076926238893, 3520.681050219568, 102.93656776245956 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 11711.586318, -8891.635516, 3216.691693 } ), new Point( new double[] { 2653.9875667012084, 4181.60078651819, 107.51853905527568 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 11070.91644, -9557.786762, 3213.139616 } ), new Point( new double[] { 2011.6923045944154, 3513.598776666881, 110.35896771552083 } ) ) );
+
+		final double weight = 1. / pointMatches.size();
+		for ( final PointMatch pointMatch : pointMatches )
+			pointMatch.setWeights( new double[] { weight } );
+
+		Collections.shuffle( pointMatches );
+
+		final AffineModel3D model = new AffineModel3D();
+		model.fit( pointMatches );
+	}
+
+	@Test
+	public void testWellDefined() throws NotEnoughDataPointsException, IllDefinedDataPointsException
+	{
+		final List< PointMatch > pointMatches = new ArrayList< PointMatch >();
+		pointMatches.add( new PointMatch( new Point( new double[] { 10109.940901, -8892.346749, 3207.829103 } ), new Point( new double[] { 1053.264137949094, 4178.499556821791, 123.9601076750317 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 10750.610779, -8226.195504, 3211.38118 } ), new Point( new double[] { 1697.794268507087, 4847.981272290586, 119.63945933786255 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 9789.623532, -8226.622244, 3206.063629 } ), new Point( new double[] { 735.531633561916, 4840.987725209846, 127.4219850438575 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 10430.269983, -8892.204503, 3209.60162 } ), new Point( new double[] { 1374.5419728598247, 4176.975761289115, 121.43534016162218 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 10430.281697, -8226.337751, 3209.608663 } ), new Point( new double[] { 1375.6180691601485, 4841.696951542491, 120.5498694360961 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 10750.599065, -8892.062256, 3211.374137 } ), new Point( new double[] { 1696.3724170447979, 4180.403160693752, 117.54197364214336 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 9469.294444, -8226.764491, 3204.291107 } ), new Point( new double[] { 419.10957349136515, 4837.719300430445, 136.8057825553509 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 9469.28273, -8892.631243, 3204.284064 } ), new Point( new double[] { 414.84339554709277, 4172.678354893637, 131.63173672791973 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 10109.952614, -8226.479997, 3207.836146 } ), new Point( new double[] { 1053.9922003467032, 4843.204481890159, 123.80925600454901 } ) ) );
+		pointMatches.add( new PointMatch( new Point( new double[] { 9789.611818, -8892.488996, 3206.056586 } ), new Point( new double[] { 733.8905377640995, 4173.987433223819, 126.7735051753456 } ) ) );
+
+		final double weight = 1. / pointMatches.size();
+		for ( final PointMatch pointMatch : pointMatches )
+			pointMatch.setWeights( new double[] { weight } );
+
+		Collections.shuffle( pointMatches );
+
+		final AffineModel3D model = new AffineModel3D();
+		model.fit( pointMatches );
+		Assert.assertTrue( model.isInvertible );
+	}
+}


### PR DESCRIPTION
Replaced equality checks for floating point numbers with approximate checks using reasonable numerical precision `1e-4`. This is to detect ill-defined points sets more robustly when fitting affine models.
Also added a unit test to ensure that the exception is thrown for an ill-defined set, while the model is properly fitted to a well-defined set.

Without the proposed fix, the exception is not thrown in the first test case (ill-defined set), and the resulting model significantly varies depending on the order of the point matches. Here are the resulting models after three separate runs using the exact same set of point matches defined in the [testIllDefined()](https://github.com/axtimwalde/mpicbg/commit/42427dca95d1b5a39340270de367f74a95868ce0#diff-64dbe86fd88c7706740d7e4e63c8484dR32) (the order is randomized by `Collections.shuffle()`):
```
Run #1: Fitted model [
    [13980.0, 26.51171875, -2526464.0, 7.963365816557809E9],
    [-2620.0, -4.583984375, 473600.0, -1.492777293964356E9],
    [1842.09375, 3.49053955078125, -332900.0, 1.0492939783688922E9]
]

Run #2: Fitted model: [
    [-2056.25, -3.90185546875, 371584.0, -1.1712216676201465E9],
    [385.125, 1.379150390625, -69536.0, 2.1918195759224105E8],
    [-270.89453125, -0.5093460083007812, 48956.0, -1.5430817202959552E8]
]

Run #3: Fitted model: [
    [-23296.0, -44.0, 4210176.0, -1.3270393724176203E10],
    [4368.0, 15.5234375, -789248.0, 2.487754956472731E9],
    [-3070.125, -5.7755126953125, 554824.0, -1.7487929725923483E9]
]
```