### PR TITLE
Fix backwards compatibility

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel1D.java
@@ -282,7 +282,6 @@ public class AffineModel1D extends AbstractAffineModel1D< AffineModel1D > implem
 		invert();
 	}
 
-	@Override
 	final public void reset()
 	{
 		m00 = 1.0; m01 = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel2D.java
@@ -373,7 +373,6 @@ public class AffineModel2D extends AbstractAffineModel2D< AffineModel2D >
 		cost = m.getCost();
 	}
 
-	@Override
 	final public void reset()
 	{
 		m00 = 1.0; m10 = 0.0; m01 = 0.0; m11 = 1.0; m02 = 0.0; m12 = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/AffineModel3D.java
@@ -546,7 +546,6 @@ public class AffineModel3D extends AbstractAffineModel3D< AffineModel3D > implem
 		invert();
 	}
 
-	@Override
 	final public void reset()
 	{
 		m00 = 1.0; m01 = 0.0; m02 = 0.0; m03 = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/ConstantModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/ConstantModel.java
@@ -54,9 +54,6 @@ public class ConstantModel< A extends Model< A >, M extends ConstantModel< A, M 
 	public void set( final M m ) {}
 
 	@Override
-	final public void reset() {}
-
-	@Override
 	public M copy()
 	{
 		@SuppressWarnings( "unchecked" )

--- a/mpicbg/src/main/java/mpicbg/models/HomographyModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/HomographyModel2D.java
@@ -231,20 +231,6 @@ public class HomographyModel2D extends AbstractModel< HomographyModel2D > implem
 	}
 
 	@Override
-	final public void reset()
-	{
-		m00 = 1; m01 = 0; m02 = 0;
-		m10 = 0; m11 = 1; m12 = 0;
-		m20 = 0; m21 = 0; m22 = 1;
-
-		i00 = 1; i01 = 0; i02 = 0;
-		i10 = 0; i11 = 1; i12 = 0;
-		i20 = 0; i21 = 0; i22 = 1;
-
-		cost = Double.MAX_VALUE;
-	}
-
-	@Override
 	public HomographyModel2D copy()
 	{
 		final HomographyModel2D m = new HomographyModel2D();

--- a/mpicbg/src/main/java/mpicbg/models/IdentityModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/IdentityModel.java
@@ -85,12 +85,6 @@ public class IdentityModel extends AbstractModel< IdentityModel > implements
 	}
 
 	@Override
-	final public void reset()
-	{
-		cost = Double.MAX_VALUE;
-	}
-
-	@Override
 	final public void preConcatenate( final IdentityModel m ) {}
 
 	@Override

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -70,13 +70,6 @@ final public class InterpolatedAffineModel1D<
 	}
 
 	@Override
-	public void reset()
-	{
-		super.reset();
-		affine.reset();
-	}
-
-	@Override
 	public InterpolatedAffineModel1D< A, B > copy()
 	{
 		final InterpolatedAffineModel1D< A, B > copy = new InterpolatedAffineModel1D< A, B >( a.copy(), b.copy(), lambda );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -152,6 +152,23 @@ final public class InterpolatedAffineModel1D<
 		affine.toMatrix( data );
 	}
 
+	/**
+	 * Initialize the model such that the respective affine transform is:
+	 *
+	 * <pre>
+	 * m0 m1
+	 * 0   1
+	 * </pre>
+	 *
+	 * @param m0
+	 * @param m1
+	 */
+	@Deprecated
+	final public void set( final float m0, final float m1 )
+	{
+		affine.set( m0, m1 );
+	}
+
 	@Override
 	public void estimateBounds( final double[] min, final double[] max )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -165,6 +165,41 @@ final public class InterpolatedAffineModel2D<
 		affine.toMatrix( data );
 	}
 
+	/**
+	 * Initialize the model such that the respective affine transform is:
+	 *
+	 * <pre>
+	 * m00 m01 m02
+	 * m10 m11 m12
+	 * 0   0   1
+	 * </pre>
+	 *
+	 * @param m00
+	 * @param m10
+	 *
+	 * @param m01
+	 * @param m11
+	 *
+	 * @param m02
+	 * @param m12
+	 */
+	@Deprecated
+	final public void set( final double m00, final double m10, final double m01, final double m11, final double m02, final double m12 )
+	{
+		affine.set( m00, m10, m01, m11, m02, m12 );
+	}
+
+	/**
+	 * Initialize the model with the parameters of an {@link AffineTransform}.
+	 *
+	 * @param a
+	 */
+	@Deprecated
+	final public void set( final AffineTransform a )
+	{
+		affine.set( a );
+	}
+
 	@Override
 	public void estimateBounds( final double[] min, final double[] max )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -71,13 +71,6 @@ final public class InterpolatedAffineModel2D<
 	}
 
 	@Override
-	public void reset()
-	{
-		super.reset();
-		affine.reset();
-	}
-
-	@Override
 	public InterpolatedAffineModel2D< A, B > copy()
 	{
 		final InterpolatedAffineModel2D< A, B > copy = new InterpolatedAffineModel2D< A, B >( a.copy(), b.copy(), lambda );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -70,13 +70,6 @@ final public class InterpolatedAffineModel3D<
 	}
 
 	@Override
-	public void reset()
-	{
-		super.reset();
-		affine.reset();
-	}
-
-	@Override
 	public InterpolatedAffineModel3D< A, B > copy()
 	{
 		final InterpolatedAffineModel3D< A, B > copy = new InterpolatedAffineModel3D< A, B >( a.copy(), b.copy(), lambda );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedModel.java
@@ -87,14 +87,6 @@ public class InterpolatedModel< A extends Model< A >, B extends Model< B >, M ex
 	}
 
 	@Override
-	public void reset()
-	{
-		a.reset();
-		b.reset();
-		cost = Double.MAX_VALUE;
-	}
-
-	@Override
 	public M copy()
 	{
 		@SuppressWarnings( "unchecked" )

--- a/mpicbg/src/main/java/mpicbg/models/Model.java
+++ b/mpicbg/src/main/java/mpicbg/models/Model.java
@@ -402,12 +402,6 @@ public interface Model< M extends Model< M > > extends CoordinateTransform
 	public void set( final M m );
 
 	/**
-	 * Reset the model to its default state.
-	 */
-	public void reset();
-
-
-	/**
 	 * Clone the model.
 	 */
 	public M copy();

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel2D.java
@@ -361,7 +361,6 @@ public class RigidModel2D extends AbstractAffineModel2D< RigidModel2D >
 		cost = m.cost;
 	}
 
-	@Override
 	final public void reset()
 	{
 		cos = 1.0; sin = 0.0; tx = 0.0; ty = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
@@ -265,7 +265,6 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 		invert();
 	}
 
-	@Override
 	final public void reset()
 	{
 		m00 = 1.0; m01 = 0.0; m02 = 0.0; m03 = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/RigidModel3D.java
@@ -459,7 +459,8 @@ public class RigidModel3D extends AbstractAffineModel3D< RigidModel3D > implemen
 	 * @param m22
 	 * @param m23
 	 */
-	final private void set(
+	@Deprecated
+	final public void set(
 			final double m00, final double m01, final double m02, final double m03,
 			final double m10, final double m11, final double m12, final double m13,
 			final double m20, final double m21, final double m22, final double m23 )

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel2D.java
@@ -377,7 +377,6 @@ public class SimilarityModel2D extends AbstractAffineModel2D< SimilarityModel2D 
 		cost = m.cost;
 	}
 
-	@Override
 	final public void reset()
 	{
 		scos = 1.0; ssin = 0.0; tx = 0.0; ty = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/SimilarityModel3D.java
@@ -409,7 +409,6 @@ public class SimilarityModel3D extends AbstractAffineModel3D< SimilarityModel3D 
 		invert();
 	}
 
-	@Override
 	final public void reset()
 	{
 		m00 = 1.0; m01 = 0.0; m02 = 0.0; m03 = 0.0;

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel1D.java
@@ -202,13 +202,6 @@ public class TranslationModel1D extends AbstractAffineModel1D< TranslationModel1
 	}
 
 	@Override
-	final public void reset()
-	{
-		t = 0;
-		cost = Double.MAX_VALUE;
-	}
-
-	@Override
 	final public void preConcatenate( final TranslationModel1D m )
 	{
 		t += m.t;

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
@@ -233,13 +233,6 @@ public class TranslationModel2D extends AbstractAffineModel2D< TranslationModel2
 	}
 
 	@Override
-	final public void reset()
-	{
-		tx = ty = 0;
-		cost = Double.MAX_VALUE;
-	}
-
-	@Override
 	final public void preConcatenate( final TranslationModel2D m )
 	{
 		tx += m.tx;

--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel3D.java
@@ -138,13 +138,6 @@ public class TranslationModel3D extends AbstractAffineModel3D< TranslationModel3
 	}
 
 	@Override
-	final public void reset()
-	{
-		translation[ 0 ] = translation[ 1 ] = translation[ 2 ] = 0;
-		cost = Double.MAX_VALUE;
-	}
-
-	@Override
 	public TranslationModel3D copy()
 	{
 		final TranslationModel3D m = new TranslationModel3D();


### PR DESCRIPTION
Some of the changes introduced in my PR #42 were overlooked and broke backwards compatibility. This PR fixes it:
* `reset()` ended up being used directly and was not actually required to be abstract
* old unsafe `set()` methods for models were restored and marked as deprecated