### PR TITLE
Fix error in writing out the transformation matrix in toMatrix(double[])

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/TranslationModel2D.java
@@ -297,6 +297,6 @@ public class TranslationModel2D extends AbstractAffineModel2D< TranslationModel2
 		data[ 0 ][ 2 ] = tx;
 		data[ 1 ][ 0 ] = 0;
 		data[ 1 ][ 1 ] = 1;
-		data[ 1 ][ 1 ] = ty;
+		data[ 1 ][ 2 ] = ty;
 	}
 }


### PR DESCRIPTION
Seems like nobody ever has used the ```TranslationModel2D.getMatrix``` method.