### PR TITLE
Specify which channel to use to perform alignment 

### DIFF
--- a/mpicbg_/pom.xml
+++ b/mpicbg_/pom.xml
@@ -115,6 +115,16 @@
 			<artifactId>ij</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-legacy</artifactId>
+		</dependency>
+
 		<!-- Third party dependencies -->
 		<dependency>
 			<groupId>gov.nist.math</groupId>


### PR DESCRIPTION
With this PR we (@NicoKiaru and I  ) propose to add an extra parameter, the channel to use for the registration. 
The transformation is then applied to all the channels. 
Multi-channel images can now be registered based on a channel of interest.

Tested on 1 channel, 2 channels composite and RGB image.
impInfo is only made for the channel of interest 
(Adds net.imagej dependency)
