### PR TITLE
the current version sometimes ends up with pointmatches having a high…

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/AbstractModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/AbstractModel.java
@@ -323,7 +323,7 @@ A:		while ( i < iterations )
 
 			int numInliers = 0;
 			boolean isGood = m.test( candidates, tempInliers, epsilon, minInlierRatio );
-			while ( isGood && numInliers < tempInliers.size() )
+			while ( isGood && numInliers != tempInliers.size() )
 			{
 				numInliers = tempInliers.size();
 				try { m.fit( tempInliers ); }


### PR DESCRIPTION
…er error than epsilon if one re-fits the model using the inliers. It has to iterate until the number of inliers didn't change once