### PR TITLE
remove logging to improve performance

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -225,7 +225,7 @@ public class TileUtil
 				tc.updateErrors();
 				observer.add( tc.getError() );
 
-				IJ.log( i + ": " + observer.mean + " " + observer.max );
+				// IJ.log( i + ": " + observer.mean + " " + observer.max );
 
 				if ( i > maxPlateauwidth )
 				{


### PR DESCRIPTION
commenting the IJ.log improves performance approximately 12-fold.
This is especially relevant when using BigStitcher / Multiviewreconstruction on a datasest with many tiles and time points.

- I tested this using a small h5/xml dataset containing 4 tiles, 3 time points, 1 channel, 1 illumination, 1 angle (total size 1.2GB)
- Using Bigstitcher with advanced grouping, comparing both tiles AND time points results in 40 comparisons.
- using latest vanilla Fiji + Bigstitcher (BigStitcher v1.1.5 v, multiview-reconstruction v1.2.9, mpicbg v1.4.2 ):
- executing the step "optimize globally and apply shifts" with two round optimization method selected:
- BEFORE: 25 seconds
- AFTER: 2 seconds

@StephanPreibisch  @tpietzsch 