### PR TITLE
Fix inversion of InterpolatedModel

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -108,9 +108,7 @@ final public class InterpolatedAffineModel1D<
 	@Override
 	public InterpolatedAffineModel1D< A, B > createInverse()
 	{
-		final InterpolatedAffineModel1D< A, B > inverse = new InterpolatedAffineModel1D< A, B >( a.createInverse(), b.createInverse(), lambda );
-		inverse.cost = cost;
-		return inverse;
+		throw creatingInverseNotSupportedException;
 	}
 
 	public AffineModel1D createAffineModel1D()

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -35,9 +35,9 @@ final public class InterpolatedAffineModel1D<
 {
 	private static final long serialVersionUID = 2662227348414849267L;
 
-	final protected AffineModel1D affine = new AffineModel1D();
-	final protected double[] afs = new double[ 2 ];
-	final protected double[] bfs = new double[ 2 ];
+	private final AffineModel1D affine = new AffineModel1D();
+	private final double[] afs = new double[ 2 ];
+	private final double[] bfs = new double[ 2 ];
 
 	public InterpolatedAffineModel1D( final A model, final B regularizer, final double lambda )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel1D.java
@@ -92,14 +92,6 @@ final public class InterpolatedAffineModel1D<
 	}
 
 	@Override
-	public double[] applyInverse( final double[] point ) throws NoninvertibleModelException
-	{
-		final double[] copy = point.clone();
-		applyInverseInPlace( copy );
-		return copy;
-	}
-
-	@Override
 	public void applyInverseInPlace( final double[] point ) throws NoninvertibleModelException
 	{
 		affine.applyInverseInPlace( point );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -109,9 +109,7 @@ final public class InterpolatedAffineModel2D<
 	@Override
 	public InterpolatedAffineModel2D< A, B > createInverse()
 	{
-		final InterpolatedAffineModel2D< A, B > inverse = new InterpolatedAffineModel2D< A, B >( a.createInverse(), b.createInverse(), lambda );
-		inverse.cost = cost;
-		return inverse;
+		throw creatingInverseNotSupportedException;
 	}
 
 	public AffineModel2D createAffineModel2D()

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -36,9 +36,9 @@ final public class InterpolatedAffineModel2D<
 {
 	private static final long serialVersionUID = -5646709386458263066L;
 
-	final protected AffineModel2D affine = new AffineModel2D();
-	final protected double[] afs = new double[ 6 ];
-	final protected double[] bfs = new double[ 6 ];
+	private final AffineModel2D affine = new AffineModel2D();
+	private final double[] afs = new double[ 6 ];
+	private final double[] bfs = new double[ 6 ];
 
 	public InterpolatedAffineModel2D( final A model, final B regularizer, final double lambda )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel2D.java
@@ -93,14 +93,6 @@ final public class InterpolatedAffineModel2D<
 	}
 
 	@Override
-	public double[] applyInverse( final double[] point ) throws NoninvertibleModelException
-	{
-		final double[] copy = point.clone();
-		applyInverseInPlace( copy );
-		return copy;
-	}
-
-	@Override
 	public void applyInverseInPlace( final double[] point ) throws NoninvertibleModelException
 	{
 		affine.applyInverseInPlace( point );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -92,14 +92,6 @@ final public class InterpolatedAffineModel3D<
 	}
 
 	@Override
-	public double[] applyInverse( final double[] point ) throws NoninvertibleModelException
-	{
-		final double[] copy = point.clone();
-		applyInverseInPlace( copy );
-		return copy;
-	}
-
-	@Override
 	public void applyInverseInPlace( final double[] point ) throws NoninvertibleModelException
 	{
 		affine.applyInverseInPlace( point );

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -108,9 +108,7 @@ final public class InterpolatedAffineModel3D<
 	@Override
 	public InterpolatedAffineModel3D< A, B > createInverse()
 	{
-		final InterpolatedAffineModel3D< A, B > inverse = new InterpolatedAffineModel3D< A, B >( a.createInverse(), b.createInverse(), lambda );
-		inverse.cost = cost;
-		return inverse;
+		throw creatingInverseNotSupportedException;
 	}
 
 	public AffineModel3D createAffineModel3D()

--- a/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
+++ b/mpicbg/src/main/java/mpicbg/models/InterpolatedAffineModel3D.java
@@ -32,9 +32,9 @@ final public class InterpolatedAffineModel3D<
 {
 	private static final long serialVersionUID = -6834487125812773082L;
 
-	final protected AffineModel3D affine = new AffineModel3D();
-	final protected double[] afs = new double[ 12 ];
-	final protected double[] bfs = new double[ 12 ];
+	private final AffineModel3D affine = new AffineModel3D();
+	private final double[] afs = new double[ 12 ];
+	private final double[] bfs = new double[ 12 ];
 
 	public InterpolatedAffineModel3D( final A model, final B regularizer, final double lambda )
 	{

--- a/mpicbg/src/main/java/mpicbg/models/InvertibleInterpolatedModel.java
+++ b/mpicbg/src/main/java/mpicbg/models/InvertibleInterpolatedModel.java
@@ -20,6 +20,11 @@ package mpicbg.models;
 /**
  * Invertible specialization of {@link InterpolatedModel}.
  *
+ * For invertible matrices A and B, the interpolated model l*A + (1-l)*B does not have to be invertible. In particular,
+ * the inverse can never be expressed in terms of A^{-1} and B^{-1}, in general.
+ * However, in some cases, the action of the inverse on a point can be computed. Subclasses have to provide this
+ * behavior as {@link #applyInverseInPlace(double[])}, but should never implement {@link #createInverse()}.
+ *
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
  */
 public class InvertibleInterpolatedModel<
@@ -28,6 +33,9 @@ public class InvertibleInterpolatedModel<
 		M extends InvertibleInterpolatedModel< A, B, M > > extends InterpolatedModel< A, B, M > implements InvertibleCoordinateTransform
 {
 	private static final long serialVersionUID = -1800786784345843623L;
+	protected static final RuntimeException creatingInverseNotSupportedException = new UnsupportedOperationException(
+			"Inverse of an InterpolatedModel cannot be expressed in terms of InterpolatedModel. " +
+			"Use applyInverse[InPlace] instead.");
 
 	public InvertibleInterpolatedModel( final A a, final B b, final double lambda )
 	{
@@ -54,22 +62,13 @@ public class InvertibleInterpolatedModel<
 	@Override
 	public void applyInverseInPlace( final double[] point ) throws NoninvertibleModelException
 	{
-		final double[] copy = b.applyInverse( point );
-		a.applyInverseInPlace( point );
-
-		for ( int d = 0; d < point.length; ++d )
-		{
-			final double dd = copy[ d ] - point[ d ];
-			point[ d ] += lambda * dd;
-		}
+		throw new UnsupportedOperationException("Inverse cannot be applied for general interpolated models. " +
+														"Subclasses should implement this behavior if suitable.");
 	}
 
 	@Override
 	public InvertibleCoordinateTransform createInverse()
 	{
-		@SuppressWarnings( "unchecked" )
-		final InvertibleInterpolatedModel< A, B, M > inverse = new InvertibleInterpolatedModel< A, B, M >( ( A )a.createInverse(), ( B )b.createInverse(), lambda );
-		inverse.cost = cost;
-		return inverse;
+		throw creatingInverseNotSupportedException;
 	}
 }


### PR DESCRIPTION
As described in #66 and discussed with @axtimwalde, the current inversion of interpolated models is not correct. To fix this, I changed the following things:
* `createInverse()` always throws `UnsupportedOperationException` since the inverse can never be expressed in terms of `InterpolatedModel`.
* `applyInverseInPlace()` throws an exception in `InvertibleInterpolatedModel`, but is overwritten in the affine subclasses (that correctly apply the inverse of the stored affine model).

### Alternative approaches
I tried to make `InvertibleInterpolatedModel` abstract or `createInverse()` final, but because of the intricate class hierarchy, this creates further problems that would need API changes to resolve.