### PR TITLE
Improve concurrent optimization

### DIFF
--- a/mpicbg/src/main/java/mpicbg/models/TileConfiguration.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileConfiguration.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -341,7 +340,7 @@ public class TileConfiguration implements Serializable
 			final double maxAllowedError,
 			final int maxIterations,
 			final int maxPlateauwidth,
-			final double damp ) throws NotEnoughDataPointsException, IllDefinedDataPointsException, InterruptedException, ExecutionException
+			final double damp ) throws InterruptedException, ExecutionException
 	{
 		TileUtil.optimizeConcurrently(observer, maxAllowedError, maxIterations, maxPlateauwidth, damp,
 				this, tiles, fixedTiles, Runtime.getRuntime().availableProcessors());

--- a/mpicbg/src/main/java/mpicbg/models/TileConfiguration.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileConfiguration.java
@@ -134,7 +134,7 @@ public class TileConfiguration implements Serializable
 	protected void apply(final ThreadPoolExecutor executor) {
 		final List<Tile<?>> allTiles = new ArrayList<>(tiles);
 		final int nTiles = allTiles.size();
-		final int nThreads = executor.getActiveCount();
+		final int nThreads = executor.getMaximumPoolSize();
 		final int tilesPerThread = nTiles / nThreads + (nTiles % nThreads == 0 ? 0 : 1);
 		final List<Future<Void>> applyTasks = new ArrayList<>(nThreads);
 

--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -21,23 +21,24 @@ import ij.IJ;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
  *
  * @author Albert Cardona
  * @author Stephan Saalfeld &lt;saalfelds@janelia.hhmi.org&gt;
+ * @author Michael Innerberger
  */
 public class TileUtil
 {
@@ -125,33 +126,22 @@ public class TileUtil
 			final int maxPlateauwidth,
 			final double damp,
 			final TileConfiguration tc,
-			final Set< Tile< ? > > tiles,
-			final Set< Tile< ? > > fixedTiles,
-			final int nThreads) throws InterruptedException, ExecutionException
-	{
-		final ThreadGroup tg = Thread.currentThread().getThreadGroup();
-		final ExecutorService exe = Executors.newFixedThreadPool(
-				nThreads,
-				new ThreadFactory() {
-					final AtomicInteger c = new AtomicInteger(0);
-					@Override
-					public Thread newThread(final Runnable r) {
-						final Thread t = new Thread(tg, r, "tile-fit-and-apply-" + c.incrementAndGet());
-						t.setPriority(Thread.NORM_PRIORITY);
-						return t;
-					}
-				});
+			final Set<Tile<?>> tiles,
+			final Set<Tile<?>> fixedTiles,
+			final int nThreads) {
+
+		final ExecutorService executor = Executors.newFixedThreadPool(nThreads);
 
 		try {
 
 			final long t0 = System.currentTimeMillis();
 
-			final ArrayList<Tile<?>> shuffledTiles = new ArrayList<Tile<?>>(tiles.size() - fixedTiles.size());
+			final List<Tile<?>> freeTiles = new ArrayList<>(tiles.size() - fixedTiles.size());
 			for (final Tile<?> t : tiles) {
 				if (fixedTiles.contains(t)) continue;
-				shuffledTiles.add(t);
+				freeTiles.add(t);
 			}
-			Collections.shuffle(shuffledTiles);
+			Collections.shuffle(freeTiles);
 
 
 			final long t1 = System.currentTimeMillis();
@@ -168,77 +158,41 @@ public class TileUtil
 
 			System.out.println("First apply took " + (t2 - t1) + " ms");
 
-			final LinkedHashMap<Tile<?>, Future<?>> executingTiles = new LinkedHashMap<Tile<?>, Future<?>>();
-			final LinkedList<Tile<?>> finishedTiles = new LinkedList<Tile<?>>();
+			final Set<Tile<?>> executingTiles = ConcurrentHashMap.newKeySet();
 
-			while ( proceed )
-			{
-				/*
-				for ( final Tile< ? > tile : tiles )
-				{
-					if ( fixedTiles.contains( tile ) ) continue;
-					tile.fitModel();
-					tile.apply();
+			while (proceed) {
+				Collections.shuffle(freeTiles);
+				final Deque<Tile<?>> pending = new ConcurrentLinkedDeque<>(freeTiles);
+				final List<Future<Void>> tasks = new ArrayList<>(nThreads);
+
+
+				for (int j = 0; j < nThreads; j++) {
+					tasks.add(executor.submit(() -> fitAndApplyWorker(pending, executingTiles, damp)));
 				}
-				*/
 
-				final LinkedList<Tile<?>> pending = new LinkedList<Tile<?>>(shuffledTiles);
-				Collections.shuffle(pending);
-
-				while (!pending.isEmpty()) {
-					final Tile<?> tile = pending.removeFirst();
-					if (intersects(tile.getConnectedTiles(), executingTiles.keySet())) {
-						pending.addLast(tile);
-					} else {
-						executingTiles.put(tile, exe.submit(new Runnable() {
-							@Override
-							public void run() {
-								try {
-									tile.fitModel();
-									tile.apply( damp );
-								} catch (final Exception e) {
-									throw new RuntimeException(e);
-								} finally {
-									synchronized (finishedTiles) {
-										finishedTiles.add(tile);
-									}
-								}
-							}
-						}));
-					}
-
-					// Wait until a group of active tasks finishes (or all of them if there are no any pending tiles)
-					if (pending.isEmpty() || executingTiles.size() > nThreads * 4) {
-						final Iterator<Future<?>> futuresIterator = executingTiles.values().iterator();
-						for (int processed = 0; processed < (pending.isEmpty() ? executingTiles.size() : nThreads); ++processed) {
-							futuresIterator.next().get();
-						}
-					}
-					// Process finished tasks which could have thrown an exception
-					synchronized (finishedTiles) {
-						while (!finishedTiles.isEmpty()) {
-							executingTiles.remove(finishedTiles.removeFirst()).get();
-						}
+				for (final Future<Void> task : tasks) {
+					try {
+						task.get();
+					} catch (final InterruptedException | ExecutionException e) {
+						throw new RuntimeException(e);
 					}
 				}
 
 				tc.updateErrors();
-				observer.add( tc.getError() );
+				observer.add(tc.getError());
 
-				// IJ.log( i + ": " + observer.mean + " " + observer.max );
+				IJ.log(i + ": " + observer.mean + " " + observer.max);
 
-				if ( i > maxPlateauwidth )
-				{
+				if (i > maxPlateauwidth) {
 					proceed = tc.getError() > maxAllowedError;
 
 					int d = maxPlateauwidth;
-					while ( !proceed && d >= 1 )
-					{
-						try
-						{
-							proceed |= Math.abs( observer.getWideSlope( d ) ) > 0.0001;
+					while (!proceed && d >= 1) {
+						try {
+							proceed |= Math.abs(observer.getWideSlope(d)) > 0.0001;
+						} catch (final Exception e) {
+							e.printStackTrace();
 						}
-						catch ( final Exception e ) { e.printStackTrace(); }
 						d /= 2;
 					}
 				}
@@ -251,23 +205,30 @@ public class TileUtil
 			System.out.println("Concurrent tile optimization loop took " + (t3 - t2) + " ms, total took " + (t3 - t0) + " ms");
 
 		} finally {
-			exe.shutdownNow();
+			executor.shutdownNow();
 		}
 	}
 
-	/** Whether {@param a} and {@param b} have any element in common. */
-	private static boolean intersects(final Set<Tile<?>> a, final Set<Tile<?>> b) {
-		final Set<Tile<?>> large, small;
-		if (a.size() > b.size()) {
-			large = a;
-			small = b;
-		} else {
-			large = b;
-			small = a;
+	private static Void fitAndApplyWorker(
+			final Deque<Tile<?>> pendingTiles,
+			final Set<Tile<?>> executingTiles,
+			final double damp
+	) throws NotEnoughDataPointsException, IllDefinedDataPointsException {
+		while (true) {
+			final Tile<?> tile = pendingTiles.pollFirst();
+			if (tile == null)
+				return null;
+
+			executingTiles.add(tile);
+			final boolean success = Collections.disjoint(tile.getConnectedTiles(), executingTiles);
+
+			if (success) {
+				tile.fitModel();
+				tile.apply(damp);
+			} else {
+				pendingTiles.addLast(tile);
+			}
+			executingTiles.remove(tile);
 		}
-		for (final Tile<?> t : small) {
-			if (large.contains(t)) return true;
-		}
-		return false;
 	}
 }

--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -174,7 +174,7 @@ public class TileUtil
 					}
 				}
 
-				tc.updateErrors();
+				tc.updateErrors(executor);
 				observer.add(tc.getError());
 
 				IJ.log(i + ": " + observer.mean + " " + observer.max);

--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -215,20 +215,22 @@ public class TileUtil
 			final double damp
 	) throws NotEnoughDataPointsException, IllDefinedDataPointsException {
 		while (true) {
+			// the polled tile can only be null if the deque is empty, i.e., there is no more work
 			final Tile<?> tile = pendingTiles.pollFirst();
 			if (tile == null)
 				return null;
 
 			executingTiles.add(tile);
-			final boolean success = Collections.disjoint(tile.getConnectedTiles(), executingTiles);
+			final boolean canBeProcessed = Collections.disjoint(tile.getConnectedTiles(), executingTiles);
 
-			if (success) {
+			if (canBeProcessed) {
 				tile.fitModel();
 				tile.apply(damp);
+				executingTiles.remove(tile);
 			} else {
+				executingTiles.remove(tile);
 				pendingTiles.addLast(tile);
 			}
-			executingTiles.remove(tile);
 		}
 	}
 }

--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -167,7 +167,8 @@ public class TileUtil
 
 
 				for (int j = 0; j < nThreads; j++) {
-					tasks.add(executor.submit(() -> fitAndApplyWorker(pending, executingTiles, damp)));
+					final boolean cleanUp = (j == 0);
+					tasks.add(executor.submit(() -> fitAndApplyWorker(pending, executingTiles, damp, cleanUp)));
 				}
 
 				for (final Future<Void> task : tasks) {
@@ -212,9 +213,12 @@ public class TileUtil
 	private static Void fitAndApplyWorker(
 			final Deque<Tile<?>> pendingTiles,
 			final Set<Tile<?>> executingTiles,
-			final double damp
+			final double damp,
+			final boolean cleanUp
 	) throws NotEnoughDataPointsException, IllDefinedDataPointsException {
-		while (true) {
+
+		final int n = pendingTiles.size();
+		for (int i = 0; (i < n) || cleanUp; i++){
 			// the polled tile can only be null if the deque is empty, i.e., there is no more work
 			final Tile<?> tile = pendingTiles.pollFirst();
 			if (tile == null)
@@ -232,5 +236,6 @@ public class TileUtil
 				pendingTiles.addLast(tile);
 			}
 		}
+		return null;
 	}
 }

--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -119,7 +119,7 @@ public class TileUtil
 		};
 	}
 
-	static public final void optimizeConcurrently(
+	static public void optimizeConcurrently(
 			final ErrorStatistic observer,
 			final double maxAllowedError,
 			final int maxIterations,
@@ -129,6 +129,30 @@ public class TileUtil
 			final Set<Tile<?>> tiles,
 			final Set<Tile<?>> fixedTiles,
 			final int nThreads) {
+
+		optimizeConcurrently(observer,
+							 maxAllowedError,
+							 maxIterations,
+							 maxPlateauwidth,
+							 damp,
+							 tc,
+							 tiles,
+							 fixedTiles,
+							 nThreads,
+							 false);
+	}
+
+	static public void optimizeConcurrently(
+			final ErrorStatistic observer,
+			final double maxAllowedError,
+			final int maxIterations,
+			final int maxPlateauwidth,
+			final double damp,
+			final TileConfiguration tc,
+			final Set<Tile<?>> tiles,
+			final Set<Tile<?>> fixedTiles,
+			final int nThreads,
+			final boolean verbose) {
 
 		// only ThreadPoolExecutors know how many threads are currently running
 		final ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool(nThreads);
@@ -177,7 +201,9 @@ public class TileUtil
 				tc.updateErrors(executor);
 				observer.add(tc.getError());
 
-				IJ.log(i + ": " + observer.mean + " " + observer.max);
+				if (verbose) {
+					IJ.log(i + ": " + tc.getError() + " " + observer.max);
+				}
 
 				if (i > maxPlateauwidth) {
 					proceed = tc.getError() > maxAllowedError;

--- a/mpicbg/src/main/java/mpicbg/models/TileUtil.java
+++ b/mpicbg/src/main/java/mpicbg/models/TileUtil.java
@@ -211,7 +211,7 @@ public class TileUtil
 					int d = maxPlateauwidth;
 					while (!proceed && d >= 1) {
 						try {
-							proceed |= Math.abs(observer.getWideSlope(d)) > 0.0001;
+							proceed = Math.abs(observer.getWideSlope(d)) > 0.0001;
 						} catch (final Exception e) {
 							e.printStackTrace();
 						}


### PR DESCRIPTION
I improved the implementation of the concurrent optimization loop in `TileUtil`. Instead of scheduling being handled by one thread and the actual work being done by `nThreads` worker threads (resulting in `nThreads + 1` threads being used), scheduling is now offloaded to the `nThreads` worker threads (resulting in only `nThreads` threads being used) by means of concurrent collections.

### Runtime
I ran a few small experiments: a NxN layout of 2D tiles with M exact matches to their spatial neighbors. Each tile was perturbed by a random (with fixed seed) shift. A 2D translation was fitted. The optimization reduced the error to `1e-4` without a plateau. For three different `NxN, M` layouts, I compare the proposed algorithm (PR) and the pre-existing concurrent optimization (orig) for 1 to 32 threads on a machine with 40 physical cores, as well as the single-threaded performance (second row).
Since the number of iterations varies because of random shuffling, I printed the runtimes per iteration for better comparison.
```
       (100x100, 10)  (50x50, 100)  (10x10, 1000)
single:     52ms          142ms          113ms
          PR  orig      PR   orig      PR   orig
01:      55ms 66ms    148ms 152ms    110ms 117ms
02:      34ms 48ms     73ms 112ms     56ms  92ms
04:      21ms 40ms     52ms  95ms     35ms  49ms
08:      18ms 39ms     33ms  86ms     18ms  34ms
16:      13ms 40ms     25ms  87ms     13ms  34ms
32:      16ms 51ms     24ms  90ms     13ms  35ms

```
### Details
The new algorithm is locking-free. It consists of four steps for every tile:
1. Signal beginning of work by accessing shared collections.
2. Neighborhood check.
3. Process (=fit and apply) the tile based on outcome of neighborhood check.
4. Signal end of work by accessing shared collections.

Concurrent access to the collection of pending tiles ([`ConcurrentLinkedDeque`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentLinkedDeque.html)) and currently executing tiles ([`ConcurrentHashMap.newKeySet()`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html#newKeySet--)) is handled by the collections themselves. Checking whether a neighboring tile is currently being processed is handled by the individual threads as is subsequent action (processing or deferring the tile). In contrast to the prior implementation, two neighboring tiles can be checked at the same time (but they cannot be processed at the same time; see below).

Apart from re-organizing the main fit-apply loop, I also added parallelized versions of `TileCollection::updateErrors` and `TileCollection::apply`. In for the cases I've tested, this played a significant role to reduce the overall runtime.

Also, I added a boolean flag to indicate whether logging is desired or not (the default being false). The logging output now prints `TileCollection::getError` instead of `ErrorStatistics::mean`, which is the correct value here, I believe.

Finally, I fixed some IDE warnings and deleted some commented code that seemed to be used for parallelizing at some point. As a disclaimer, I did not adhere to the prevalent coding style, since my IDE actively deletes spaces when moving things around.

### Correctness
The [JMM](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/package-summary.html#Weakly) gives a few guarantees about what *happens-before* something else:
* Each action in a thread *happens-before* every action in that thread that comes later in the program's order.
* Actions in a thread prior to placing an object into any concurrent collection *happen-before* actions subsequent to the access or removal of that element from the collection in another thread.

I cannot *guarantee* that this method is correct (i.e., always terminates and computes the right thing). However, I'm pretty confident for the following reasons based on above principles:
* *Each tile is handled by exactly one thread at the same time.* (Guaranteed by concurrent collections.)
* *Each tile is only inserted in the executing tiles if it's not already present.* (A tile is removed from the executing tiles *before* it is placed back in the deque.)
* *A tile cannot be processed if one of its neighbors is currently being processed.* (Neighborhood check happens *after* insertion in the executing tile set and "being in the neighborhood of" is symmetric. This does mean that two neighboring tiles can be checked at the same time, leading to none of them being processed.)
* *The algorithm processes every tile* (A tile is placed in the deque *before* the same thread polls the deque again. Therefore, at least one thread doesn't see an empty pending list as long as there is work to do.)
* *The algorithm doesn't hang if all tiles in the pending set are neighboring each other.* (In this case, there is a high chance that there is always one tile in the executing set so that the neighborhood check fails (even if this tile is never processed). There is a clean up thread to prevent this: All threads except this one will die after a certain number of attempts and the clean up thread can complete all pending tiles).

### Further steps
While we're at it, should we:
* add a method for single-threaded optimization to `TileUtil` to unify the API?
* deprecate the `TileCollection::<optimize|concurrently|silently> methods`?
* use a specialized single-threaded implementation for `nThreads == 1`?
* use a `ConcurrentLinkedQueue`-based parallelization for `TileCollection::updateErrors` and `TileCollection::apply` instead of an a-priori partition of the list of tiles? This potentially allows for better load balancing, but could have more overhead.

I'm happy for any feedback regarding correctness and efficiency in more practical situations, especially from @axtimwalde, @tpietzsch, @StephanPreibisch, and @bogovicj.