### PR TITLE
Slightly speed up SIFT matching

### DIFF
--- a/mpicbg/src/main/java/mpicbg/imagefeatures/Feature.java
+++ b/mpicbg/src/main/java/mpicbg/imagefeatures/Feature.java
@@ -68,11 +68,24 @@ public class Feature implements Comparable< Feature >, Serializable
 	final public double descriptorDistance( final Feature f )
 	{
 		double d = 0;
-		for ( int i = 0; i < descriptor.length; ++i )
-		{
-			final double a = descriptor[ i ] - f.descriptor[ i ];
+
+		// Unroll the loop to speed up the distance calculation
+		// Feature descriptor lengths are like divisible by 4
+		final int unrolledLength = descriptor.length - 3;
+		int i = 0;
+		for (; i < unrolledLength; i += 4) {
+			final double a0 = descriptor[i] - f.descriptor[i];
+			final double a1 = descriptor[i + 1] - f.descriptor[i + 1];
+			final double a2 = descriptor[i + 2] - f.descriptor[i + 2];
+			final double a3 = descriptor[i + 3] - f.descriptor[i + 3];
+			d += a0 * a0 + a1 * a1 + a2 * a2 + a3 * a3;
+		}
+
+		for (; i < descriptor.length; ++i) {
+			final double a = descriptor[i] - f.descriptor[i];
 			d += a * a;
 		}
+
 		return Math.sqrt( d );
 	}
 

--- a/mpicbg/src/main/java/mpicbg/imagefeatures/Feature.java
+++ b/mpicbg/src/main/java/mpicbg/imagefeatures/Feature.java
@@ -62,7 +62,7 @@ public class Feature implements Comparable< Feature >, Serializable
 	@Override
 	final public int compareTo( final Feature f )
 	{
-		return scale < f.scale ? 1 : scale == f.scale ? 0 : -1;
+		return Double.compare(f.scale, scale);
 	}
 
 	final public double descriptorDistance( final Feature f )
@@ -85,11 +85,11 @@ public class Feature implements Comparable< Feature >, Serializable
 	 *
 	 * @return matches
 	 */
-	final static public int matchFeatures(
-			final List< Feature > fs1,
-			final List< Feature > fs2,
-			final List< PointMatch > matches,
-			final double rod )
+	static public int matchFeatures(
+			final List<Feature> fs1,
+			final List<Feature> fs2,
+			final List<PointMatch> matches,
+			final double rod)
 	{
 		for ( final Feature f1 : fs1 )
 		{


### PR DESCRIPTION
Profiling a downstream match derivation process using the MPICBG implementation of SIFT revealed that the single largest chunk of runtime was spent on computing the distance of the derived features. By unrolling the corresponding for-loop, I was able to speed the match derivation up a little bit: ~30% with descriptor size 4, ~40% with descriptor size 7.

Even though the whole thing could be speed up even further (by a low single digit %-value) using `float` throughout the computation, I decided not to do that in order to not loose any accuracy.

Let me know what you think, @axtimwalde!