### PR TITLE
Speed up integral images

### DIFF
--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
@@ -60,7 +60,7 @@ final public class BlockPMCC
 	
 	private int fpXYWidth, fpXYHeight, offsetXX, offsetYX, offsetXY, offsetYY;
 	
-	final static private void sumAndSumOfSquares(
+	static private void sumAndSumOfSquares(
 			final FloatProcessor fp,
 			final double[] sum,
 			final double[] sumOfSquares )
@@ -110,7 +110,7 @@ final public class BlockPMCC
 		}
 	}
 	
-	final static private void sumAndSumOfSquares(
+	static private void sumAndSumOfSquares(
 			final int width,
 			final int height,
 			final FloatProcessor fp1,
@@ -259,8 +259,8 @@ final public class BlockPMCC
 		final int heightX = fpX.getHeight();
 		final int widthY = fpY.getWidth();
 		final int heightY = fpY.getHeight();
-		final int widthXY = widthX < widthY ? widthX : widthY;
-		final int heightXY = heightX < heightY ? heightX : heightY;
+		final int widthXY = Math.min(widthX, widthY);
+		final int heightXY = Math.min(heightX, heightY);
 		
 		fpR = new FloatProcessor( widthY, heightY );
 		
@@ -301,7 +301,7 @@ final public class BlockPMCC
 	}
 	
 	
-	final public FloatProcessor getTargetProcessor()
+	public FloatProcessor getTargetProcessor()
 	{
 		return fpR;
 	}
@@ -313,7 +313,7 @@ final public class BlockPMCC
 	 * @param offsetX
 	 * @param offsetY
 	 */
-	final public void setOffset( final int offsetX, final int offsetY )
+	public void setOffset( final int offsetX, final int offsetY )
 	{
 		/* TODO simple and stupid first, fast later if it works! */
 		
@@ -335,7 +335,7 @@ final public class BlockPMCC
 			a = fpX.getWidth();
 			b = fpY.getWidth() - offsetX;
 		}
-		fpXYWidth = ( a < b ? a : b );
+		fpXYWidth = Math.min(a, b);
 		
 		if ( offsetY < 0 )
 		{
@@ -351,7 +351,7 @@ final public class BlockPMCC
 			a = fpX.getHeight();
 			b = fpY.getHeight() - offsetY;
 		}
-		fpXYHeight = ( a < b ? a : b );
+		fpXYHeight = Math.min(a, b);
 		
 		
 		/* first row */
@@ -410,7 +410,7 @@ final public class BlockPMCC
 	 * @param blockRadiusX
 	 * @param blockRadiusY
 	 */
-	final public void r( final int blockRadiusX, final int blockRadiusY )
+	public void r( final int blockRadiusX, final int blockRadiusY )
 	{
 		final int width = fpR.getWidth();
 		final int w = fpXYWidth - 1;
@@ -455,7 +455,7 @@ final public class BlockPMCC
 	}
 
 	
-	final public void r( final int blockRadius )
+	public void r( final int blockRadius )
 	{
 		r( blockRadius, blockRadius );
 	}
@@ -469,7 +469,7 @@ final public class BlockPMCC
 	 * @param blockRadiusX
 	 * @param blockRadiusY
 	 */
-	final public void rSignedSquare( final int blockRadiusX, final int blockRadiusY )
+	public void rSignedSquare( final int blockRadiusX, final int blockRadiusY )
 	{
 		final int width = fpR.getWidth();
 		final int w = fpXYWidth - 1;
@@ -516,7 +516,7 @@ final public class BlockPMCC
 		}
 	}
 	
-	final public void rSignedSquare( final int blockRadius )
+	public void rSignedSquare( final int blockRadius )
 	{
 		rSignedSquare( blockRadius, blockRadius );
 	}

--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
@@ -69,43 +69,36 @@ final public class BlockPMCC
 		final int height = fp.getHeight();
 		
 		final int w = width + 1;
-		final int w1 = w + 1;
-		final int w2 = w + w;
-		
-		final int n = w * height + w;
-		final int n1 = n - w1;
-		final int n2 = n1 - w + 2;
-		
+		final int h = height + 1;
+
 		/* rows */
-		for ( int i = 0, j = w1; j < n; ++j )
-		{
-			final int end = i + width;
-			double s = sum[ j ] = fp.getf( i );
-			double ss = sumOfSquares[ j ] = s * s;
-			for ( ++i, ++j; i < end; ++i, ++j )
-			{
-				final float a = fp.getf( i );
-				s += a;
-				ss += a * a;
-				sum[ j ] = s;
-				sumOfSquares[ j ] = ss;
+		for (int j = 1; j < h; ++j) {
+			double rowSum = 0;
+			double rowSumOfSquares = 0;
+			final int offset = (j - 1) * width;
+			final int offsetSum = j * w + 1;
+
+			for (int i = 0; i < width; ++i) {
+				final float a = fp.getf(offset + i);
+				rowSum += a;
+				sum[offsetSum + i] = rowSum;
+				rowSumOfSquares += a * a;
+				sumOfSquares[offsetSum + i] = rowSumOfSquares;
 			}
 		}
-		
+
 		/* columns */
-		for ( int j = w1; j < w2; j -= n1 )
-		{
-			final int end = j + n2;
-			
-			double s = sum[ j ];
-			double ss = sumOfSquares[ j ];
-			for ( j += w; j < end; j += w )
-			{
-				s += sum[ j ];
-				ss += sumOfSquares[ j ];
-				
-				sum[ j ] = s;
-				sumOfSquares[ j ] = ss;
+		final double[] columnSum = new double[width];
+		final double[] columnSumOfSquares = new double[width];
+		for (int j = 1; j < w; ++j) {
+			final int offset = j * w + 1;
+
+			for (int i = 0; i < height; ++i) {
+				final int index = offset + i;
+				columnSum[i] += sum[index];
+				sum[index] = columnSum[i];
+				columnSumOfSquares[i] += sumOfSquares[index];
+				sumOfSquares[index] = columnSumOfSquares[i];
 			}
 		}
 	}
@@ -121,57 +114,51 @@ final public class BlockPMCC
 			final double[] sumOfSquares2 )
 	{
 		final int w = width + 1;
-		final int w1 = w + 1;
-		final int w2 = w + w;
-		
-		final int n = w * height + w;
-		final int n1 = n - w1;
-		final int n2 = n1 - w + 2;
-		
+		final int h = height + 1;
+
 		/* rows */
-		for ( int i = 0, j = w1; j < n; ++j )
-		{
-			final int end = i + width;
-			double s1 = sum1[ j ] = fp1.getf( i );
-			double ss1 = sumOfSquares1[ j ] = s1 * s1;
-			double s2 = sum2[ j ] = fp2.getf( i );
-			double ss2 = sumOfSquares2[ j ] = s2 * s2;
-			for ( ++i, ++j; i < end; ++i, ++j )
-			{
-				final float a1 = fp1.getf( i );
-				s1 += a1;
-				ss1 += a1 * a1;
-				sum1[ j ] = s1;
-				sumOfSquares1[ j ] = ss1;
-				
-				final float a2 = fp2.getf( i );
-				s2 += a2;
-				ss2 += a2 * a2;
-				sum2[ j ] = s2;
-				sumOfSquares2[ j ] = ss2;
+		for (int j = 1; j < h; ++j) {
+			double rowSum1 = 0;
+			double rowSumOfSquares1 = 0;
+			double rowSum2 = 0;
+			double rowSumOfSquares2 = 0;
+			final int offset = (j - 1) * width;
+			final int offsetSum = j * w + 1;
+
+			for (int i = 0; i < width; ++i) {
+				final float a = fp1.getf(offset + i);
+				rowSum1 += a;
+				sum1[offsetSum + i] = rowSum1;
+				rowSumOfSquares1 += a * a;
+				sumOfSquares1[offsetSum + i] = rowSumOfSquares1;
+
+				final float b = fp2.getf(offset + i);
+				rowSum2 += b;
+				sum2[offsetSum + i] = rowSum2;
+				rowSumOfSquares2 += b * b;
+				sumOfSquares2[offsetSum + i] = rowSumOfSquares2;
 			}
 		}
-		
+
 		/* columns */
-		for ( int j = w1; j < w2; j -= n1 )
-		{
-			final int end = j + n2;
-			
-			double s1 = sum1[ j ];
-			double ss1 = sumOfSquares1[ j ];
-			double s2 = sum2[ j ];
-			double ss2 = sumOfSquares2[ j ];
-			for ( j += w; j < end; j += w )
-			{
-				s1 += sum1[ j ];
-				ss1 += sumOfSquares1[ j ];
-				s2 += sum2[ j ];
-				ss2 += sumOfSquares2[ j ];
-				
-				sum1[ j ] = s1;
-				sumOfSquares1[ j ] = ss1;
-				sum2[ j ] = s2;
-				sumOfSquares2[ j ] = ss2;
+		final double[] columnSum1 = new double[width];
+		final double[] columnSumOfSquares1 = new double[width];
+		final double[] columnSum2 = new double[width];
+		final double[] columnSumOfSquares2 = new double[width];
+		for (int j = 1; j < w; ++j) {
+			final int offset = j * w + 1;
+
+			for (int i = 0; i < height; ++i) {
+				final int index = offset + i;
+				columnSum1[i] += sum1[index];
+				sum1[index] = columnSum1[i];
+				columnSumOfSquares1[i] += sumOfSquares1[index];
+				sumOfSquares1[index] = columnSumOfSquares1[i];
+
+				columnSum2[i] += sum2[index];
+				sum2[index] = columnSum2[i];
+				columnSumOfSquares2[i] += sumOfSquares2[index];
+				sumOfSquares2[index] = columnSumOfSquares2[i];
 			}
 		}
 	}
@@ -182,7 +169,7 @@ final public class BlockPMCC
 	 * 
 	 * <p>Note, that this constructor does not initialize &Sigma;XY.  That has
 	 * to be done for a specified offset through {@link #setOffset(int, int)}
-	 * afterwards.</p>
+	 * afterward.</p>
 	 * 
 	 * @param width
 	 * @param height
@@ -245,7 +232,7 @@ final public class BlockPMCC
 	 * 
 	 * <p>Note, that this constructor does not initialize &Sigma;XY.  That has
 	 * to be done for a specified offset through {@link #setOffset(int, int)}
-	 * afterwards.</p>
+	 * afterward.</p>
 	 * 
 	 * @param fpX
 	 * @param fpY

--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockStatistics.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockStatistics.java
@@ -148,7 +148,7 @@ public class BlockStatistics
 		}
 	}
 	
-	final static protected void integrateColumns(
+	static protected void integrateColumns(
 			final int w1,
 			final int w2,
 			final int n1,
@@ -305,7 +305,7 @@ public class BlockStatistics
 //				final float scale = 1.0f / ( xMax - xMin ) / bh;
 //				final double sum = sums.getDoubleSum( xMin, yMin, xMax, yMax );
 //				final double var = scale * ( sumsOfSquares.getDoubleSum( xMin, yMin, xMax, yMax ) - sum * sum * scale );
-				final long bs = ( xMax - xMin ) * bh;
+				final double bs = ( xMax - xMin ) * bh;
 				final double scale1 = 1.0 / ( bs - 1 );
 				final double scale2 = 1.0 / ( bs * bs - bs );
 				final double sum = sums.getDoubleSum( xMin, yMin, xMax, yMax );
@@ -350,7 +350,7 @@ public class BlockStatistics
 			{
 				final int xMin = Math.max( -1, x - blockRadiusX - 1 );
 				final int xMax = Math.min( w, x + blockRadiusX );
-				final long bs = ( xMax - xMin ) * bh;
+				final double bs = ( xMax - xMin ) * bh;
 				final double scale1 = 1.0 / ( bs - 1 );
 				final double scale2 = 1.0 / ( bs * bs - bs );
 				final double sum = sums.getDoubleSum( xMin, yMin, xMax, yMax );

--- a/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
@@ -163,16 +163,16 @@ final public class DoubleIntegralImage implements IntegralImage
 	}
 	
 	@Override
-	final public int getWidth() { return width; }
+	public int getWidth() { return width; }
 	@Override
-	final public int getHeight() { return height; }
+	public int getHeight() { return height; }
 	
-	final public double getDoubleSum( final int x, final int y )
+	public double getDoubleSum( final int x, final int y )
 	{
 		return sum[ y * w + w1 + x ];
 	}
 	
-	final public double getDoubleSum( final int xMin, final int yMin, final int xMax, final int yMax )
+	public double getDoubleSum( final int xMin, final int yMin, final int xMax, final int yMax )
 	{
 		final int y1w = yMin * w + w1;
 		final int y2w = yMax * w + w1;
@@ -180,25 +180,25 @@ final public class DoubleIntegralImage implements IntegralImage
 	}
 
 	@Override
-	final public int getSum( final int xMin, final int yMin, final int xMax, final int yMax )
+	public int getSum( final int xMin, final int yMin, final int xMax, final int yMax )
 	{
 		return Float.floatToIntBits( ( float )getDoubleSum( xMin, yMin, xMax, yMax ) );
 	}
 	
 	@Override
-	final public int getScaledSum( final int xMin, final int yMin, final int xMax, final int yMax, final float scale )
+	public int getScaledSum( final int xMin, final int yMin, final int xMax, final int yMax, final float scale )
 	{
 		final int y1w = yMin * w + w1;
 		final int y2w = yMax * w + w1;
 		return Float.floatToIntBits( ( float )( sum[ y1w + xMin ] + sum[ y2w + xMax ] - sum[ y1w + xMax ] - sum[ y2w + xMin ] ) * scale );
 	}
 	
-	final double[] getData()
+	double[] getData()
 	{
 		return sum;
 	}
 	
-	final public FloatProcessor toProcessor()
+	public FloatProcessor toProcessor()
 	{
 		final float[] pixels = new float[ width * height ];
 		for ( int y = 0; y < height; ++y )

--- a/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
@@ -51,6 +51,7 @@ final public class DoubleIntegralImage implements IntegralImage
 	final private int height;
 	
 	final private int w;
+	final private int h;
 	final private int w1;
 
 	final private double[] sum;
@@ -62,37 +63,32 @@ final public class DoubleIntegralImage implements IntegralImage
 		
 		w = width + 1;
 		w1 = w + 1;
-		
-		final int w2 = w + w;
+		h = height + 1;
 		
 		final int n = w * height + w;
-		final int n1 = n - w1;
-		final int n2 = n1 - w + 2;
-		
 		sum = new double[ n ];
 
 		/* rows */
-		for ( int i = 0, j = w1; j < n; ++j )
-		{
-			final int end = i + width;
-			double s = sum[ j ] = pixels[ i ];
-			for ( ++i, ++j; i < end; ++i, ++j )
-			{
-				s += pixels[ i ];
-				sum[ j ] = s;
+		for (int j = 1; j < h; ++j) {
+			double rowSum = 0;
+			final int offset = (j - 1) * width;
+			final int offsetSum = j * w + 1;
+
+			for (int i = 0; i < width; ++i) {
+				rowSum += pixels[offset + i];
+				sum[offsetSum + i] = rowSum;
 			}
 		}
-		
+
 		/* columns */
-		for ( int j = w1; j < w2; j -= n1 )
-		{
-			final int end = j + n2;
-			
-			double s = sum[ j ];
-			for ( j += w; j < end; j += w )
-			{
-				s += sum[ j ];
-				sum[ j ] = s;
+		final double[] columnSum = new double[width];
+		for (int j = 1; j < w; ++j) {
+			final int offset = j * w + 1;
+
+			for (int i = 0; i < height; ++i) {
+				final int index = offset + i;
+				columnSum[i] += sum[index];
+				sum[index] = columnSum[i];
 			}
 		}
 	}
@@ -112,6 +108,7 @@ final public class DoubleIntegralImage implements IntegralImage
 		
 		w = width + 1;
 		w1 = w + 1;
+		h = height + 1;
 
 		this.sum = sum;
 	}
@@ -129,6 +126,7 @@ final public class DoubleIntegralImage implements IntegralImage
 
 		w = width + 1;
 		w1 = w + 1;
+		h = height + 1;
 		
 		final int w2 = w + w;
 		

--- a/mpicbg/src/main/java/mpicbg/ij/integral/IntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/IntegralImage.java
@@ -63,8 +63,8 @@ package mpicbg.ij.integral;
  */
 public interface IntegralImage
 {
-	public int getWidth();
-	public int getHeight();
-	public int getSum( final int xMin, final int yMin, final int xMax, final int yMax );
-	public int getScaledSum( final int xMin, final int yMin, final int xMax, final int yMax, final float scale );
+	int getWidth();
+	int getHeight();
+	int getSum( final int xMin, final int yMin, final int xMax, final int yMax );
+	int getScaledSum( final int xMin, final int yMin, final int xMax, final int yMax, final float scale );
 }

--- a/mpicbg/src/main/java/mpicbg/ij/integral/LongIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/LongIntegralImage.java
@@ -62,7 +62,7 @@ final public class LongIntegralImage implements IntegralImage
 	final private int w;
 	final private int w1;
 
-	final protected long[] sum;
+	final private long[] sum;
 	
 	LongIntegralImage( final int[] pixels, final int width, final int height )
 	{
@@ -71,37 +71,32 @@ final public class LongIntegralImage implements IntegralImage
 		
 		w = width + 1;
 		w1 = w + 1;
-		
-		final int w2 = w + w;
-		
-		final int n = w * height + w;
-		final int n1 = n - w1;
-		final int n2 = n1 - w + 2;
-		
+		final int h = height + 1;
+		final int n = w * h;
+
 		sum = new long[ n ];
 
 		/* rows */
-		for ( int i = 0, j = w1; j < n; ++j )
-		{
-			final int end = i + width;
-			long s = sum[ j ] = pixels[ i ];
-			for ( ++i, ++j; i < end; ++i, ++j )
-			{
-				s += pixels[ i ];
-				sum[ j ] = s;
+		for (int j = 1; j < h; ++j) {
+			long rowSum = 0;
+			final int offset = (j - 1) * width;
+			final int offsetSum = j * w + 1;
+
+			for (int i = 0; i < width; ++i) {
+				rowSum += pixels[offset + i];
+				sum[offsetSum + i] = rowSum;
 			}
 		}
-		
+
 		/* columns */
-		for ( int j = w1; j < w2; j -= n1 )
-		{
-			final int end = j + n2;
-			
-			long s = sum[ j ];
-			for ( j += w; j < end; j += w )
-			{
-				s += sum[ j ];
-				sum[ j ] = s;
+		final long[] columnSum = new long[width];
+		for (int j = 1; j < w; ++j) {
+			final int offset = j * w + 1;
+
+			for (int i = 0; i < height; ++i) {
+				final int index = offset + i;
+				columnSum[i] += sum[index];
+				sum[index] = columnSum[i];
 			}
 		}
 	}
@@ -131,52 +126,47 @@ final public class LongIntegralImage implements IntegralImage
 
 		w = width + 1;
 		w1 = w + 1;
-		
-		final int w2 = w + w;
-		
-		final int n = w * height + w;
-		final int n1 = n - w1;
-		final int n2 = n1 - w + 2;
-		
+		final int h = height + 1;
+		final int n = w * h;
+
 		sum = new long[ n ];
 
 		/* rows */
-		for ( int i = 0, j = w1; j < n; ++j )
-		{
-			final int end = i + width;
-			long s = sum[ j ] = ip.get( i );
-			for ( ++i, ++j; i < end; ++i, ++j )
-			{
-				s += ip.get( i );
-				sum[ j ] = s;
+		for (int j = 1; j < h; ++j) {
+			long rowSum = 0;
+			final int offset = (j - 1) * width;
+			final int offsetSum = j * w + 1;
+
+			for (int i = 0; i < width; ++i) {
+				rowSum += ip.get(offset + i);
+				sum[offsetSum + i] = rowSum;
 			}
 		}
-		
+
 		/* columns */
-		for ( int j = w1; j < w2; j -= n1 )
-		{
-			final int end = j + n2;
-			
-			long s = sum[ j ];
-			for ( j += w; j < end; j += w )
-			{
-				s += sum[ j ];
-				sum[ j ] = s;
+		final long[] columnSum = new long[width];
+		for (int j = 1; j < w; ++j) {
+			final int offset = j * w + 1;
+
+			for (int i = 0; i < height; ++i) {
+				final int index = offset + i;
+				columnSum[i] += sum[index];
+				sum[index] = columnSum[i];
 			}
 		}
 	}
 	
 	@Override
-	final public int getWidth() { return width; }
+	public int getWidth() { return width; }
 	@Override
-	final public int getHeight() { return height; }
+	public int getHeight() { return height; }
 	
-	final public long getLongSum( final int x, final int y )
+	public long getLongSum( final int x, final int y )
 	{
 		return sum[ y * w + w1 + x ];
 	}
 	
-	final public long getLongSum( final int xMin, final int yMin, final int xMax, final int yMax )
+	public long getLongSum( final int xMin, final int yMin, final int xMax, final int yMax )
 	{
 		final int y1w = yMin * w + w1;
 		final int y2w = yMax * w + w1;
@@ -184,13 +174,13 @@ final public class LongIntegralImage implements IntegralImage
 	}
 	
 	@Override
-	final public int getSum( final int xMin, final int yMin, final int xMax, final int yMax )
+	public int getSum( final int xMin, final int yMin, final int xMax, final int yMax )
 	{
 		return ( int )getLongSum( xMin, yMin, xMax, yMax );
 	}
 	
 	@Override
-	final public int getScaledSum( final int xMin, final int yMin, final int xMax, final int yMax, final float scale )
+	public int getScaledSum( final int xMin, final int yMin, final int xMax, final int yMax, final float scale )
 	{
 		final int y1w = yMin * w + w1;
 		final int y2w = yMax * w + w1;

--- a/mpicbg/src/main/java/mpicbg/ij/integral/Mean.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/Mean.java
@@ -77,7 +77,7 @@ final public class Mean
 		integral = new DoubleIntegralImage( ip );
 	}
 	
-	final public void mean( final int blockRadiusX, final int blockRadiusY )
+	public void mean( final int blockRadiusX, final int blockRadiusY )
 	{
 		final int w = ip.getWidth() - 1;
 		final int h = ip.getHeight() - 1;
@@ -96,7 +96,7 @@ final public class Mean
 		}
 	}
 	
-	final public void mean( final int blockRadius )
+	public void mean( final int blockRadius )
 	{
 		mean( blockRadius, blockRadius );
 	}
@@ -110,15 +110,15 @@ final public class Mean
 	 * @param ip
 	 * @return
 	 */
-	final static public Mean create( final ImageProcessor ip )
+	static public Mean create( final ImageProcessor ip )
 	{
-		if ( FloatProcessor.class.isInstance( ip ) )
+		if (ip instanceof FloatProcessor)
 			return new Mean( ( FloatProcessor )ip );
-		else if ( ByteProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ByteProcessor)
 			return new Mean( ( ByteProcessor )ip );
-		else if ( ShortProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ShortProcessor)
 			return new Mean( ( ShortProcessor )ip );
-		else if ( ColorProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ColorProcessor)
 			return new Mean( ( ColorProcessor )ip );
 		else
 			return null;

--- a/mpicbg/src/main/java/mpicbg/ij/integral/NormalizeLocalContrast.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/NormalizeLocalContrast.java
@@ -85,7 +85,7 @@ public class NormalizeLocalContrast extends BlockStatistics
 			{
 				final int xMin = Math.max( -1, x - blockRadiusX - 1 );
 				final int xMax = Math.min( w, x + blockRadiusX );
-				final long bs = ( xMax - xMin ) * bh;
+				final double bs = ( xMax - xMin ) * bh;
 				final double scale = 1.0 / bs;
 				final double sum = sums.getDoubleSum( xMin, yMin, xMax, yMax );
 				final int i = row + x;
@@ -130,7 +130,7 @@ public class NormalizeLocalContrast extends BlockStatistics
 			{
 				final int xMin = Math.max( -1, x - blockRadiusX - 1 );
 				final int xMax = Math.min( w, x + blockRadiusX );
-				final long bs = ( xMax - xMin ) * bh;
+				final double bs = ( xMax - xMin ) * bh;
 				final double scale1 = 1.0 / ( bs - 1 );
 				final double scale2 = 1.0 / ( bs * bs - bs );
 				final double sum = sums.getDoubleSum( xMin, yMin, xMax, yMax );
@@ -178,7 +178,7 @@ public class NormalizeLocalContrast extends BlockStatistics
 			{
 				final int xMin = Math.max( -1, x - blockRadiusX - 1 );
 				final int xMax = Math.min( w, x + blockRadiusX );
-				final long bs = ( xMax - xMin ) * bh;
+				final double bs = ( xMax - xMin ) * bh;
 				final double scale = 1.0 / bs;
 				final double scale1 = 1.0 / ( bs - 1 );
 				final double scale2 = 1.0 / ( bs * bs - bs );

--- a/mpicbg/src/main/java/mpicbg/ij/integral/RemoveOutliers.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/RemoveOutliers.java
@@ -81,7 +81,7 @@ public class RemoveOutliers extends BlockStatistics
 			{
 				final int xMin = Math.max( -1, x - blockRadiusX - 1 );
 				final int xMax = Math.min( w, x + blockRadiusX );
-				final long bs = ( xMax - xMin ) * bh;
+				final double bs = ( xMax - xMin ) * bh;
 				final double scale = 1.0 / bs;
 				final double scale1 = 1.0 / ( bs - 1 );
 				final double scale2 = 1.0 / ( bs * bs - bs );

--- a/mpicbg/src/main/java/mpicbg/ij/integral/Scale.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/Scale.java
@@ -77,12 +77,12 @@ final public class Scale
 		integral = new DoubleIntegralImage( ip );
 	}
 	
-	final static private int round( final double a )
+	static private int round( final double a )
 	{
 		return ( int )( a + Math.signum( a ) * 0.5f );
 	}
 	
-	final public ImageProcessor scale( final int width, final int height )
+	public ImageProcessor scale( final int width, final int height )
 	{
 		final int w = width - 1;
 		final int h = height - 1;
@@ -96,14 +96,14 @@ final public class Scale
 		
 		for ( int y = 0; y < height; ++y )
 		{
-			final int yi = width * Math.min( h, Math.max( 0, y ) );
+			final int yi = width * Math.min(h, y);
 			final double yMinDouble = y * pixelHeight;
 			final int yMin = Math.min( hh, Math.max( -1, round( yMinDouble ) - 1 ) );
 			final int yMax = Math.max( -1, Math.min( hh, round( yMinDouble + pixelHeight - 1 ) ) );
 			final int bh = yMax - yMin;
 			for ( int x = 0; x < width; ++x )
 			{
-				final int xi = Math.min( w, Math.max( 0, x ) );
+				final int xi = Math.min(w, x);
 				final double xMinDouble = x * pixelWidth;
 				final int xMin = Math.min( ww, Math.max( -1, round( xMinDouble ) - 1 ) );
 				final int xMax = Math.min( ww, Math.max( -1, round( xMinDouble + pixelWidth - 1 ) ) );
@@ -115,7 +115,7 @@ final public class Scale
 		return target;
 	}
 	
-	final public ImageProcessor scale( final double scale )
+	public ImageProcessor scale( final double scale )
 	{
 		final int width = round( ip.getWidth() * scale );
 		final int height = round( ip.getHeight() * scale );
@@ -132,15 +132,15 @@ final public class Scale
 	 * @param ip
 	 * @return
 	 */
-	final static public Scale create( final ImageProcessor ip )
+	static public Scale create( final ImageProcessor ip )
 	{
-		if ( FloatProcessor.class.isInstance( ip ) )
+		if (ip instanceof FloatProcessor)
 			return new Scale( ( FloatProcessor )ip );
-		else if ( ByteProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ByteProcessor)
 			return new Scale( ( ByteProcessor )ip );
-		else if ( ShortProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ShortProcessor)
 			return new Scale( ( ShortProcessor )ip );
-		else if ( ColorProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ColorProcessor)
 			return new Scale( ( ColorProcessor )ip );
 		else
 			return null;

--- a/mpicbg/src/main/java/mpicbg/ij/integral/Tilt.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/Tilt.java
@@ -86,15 +86,15 @@ public class Tilt
 	 * @param ip
 	 * @return
 	 */
-	final static public Tilt create( final ImageProcessor ip )
+	static public Tilt create( final ImageProcessor ip )
 	{
-		if ( FloatProcessor.class.isInstance( ip ) )
+		if (ip instanceof FloatProcessor)
 			return new Tilt( ( FloatProcessor )ip );
-		else if ( ByteProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ByteProcessor)
 			return new Tilt( ( ByteProcessor )ip );
-		else if ( ShortProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ShortProcessor)
 			return new Tilt( ( ShortProcessor )ip );
-		else if ( ColorProcessor.class.isInstance( ip ) )
+		else if (ip instanceof ColorProcessor)
 			return new Tilt( ( ColorProcessor )ip );
 		else
 			return null;


### PR DESCRIPTION
While investigating a performance issue (which turned out to be unrelated to this library) in some downstream code, I found that some minimal changes could provide significant speedup: Integral images are accumulated row-wise and column-wise, where column-wise accumulation took significantly longer than the row-wise one.

This PR changes the memory access pattern of the column-wise accumulation to row-wise access, thereby significantly reducing the run time; see the changes in `IntIntegralImage` as an example. These are the min/max run times for 10 runs of computing the integral image for a 20000x20000 image before and after the changes:

|             | Before         | After          |
| ----------- | -------------- | -------------- |
| Row-wise    | 214ms - 267ms  | 222ms - 269ms  |
| Column-wise | 627ms - 716ms  | 131ms - 141ms  |
| Total       | 841ms - 983ms  | 353ms - 410ms  |

All changes either change the accumulation in exactly the same manner, or are IDE warnings which are automatically fixed. For the former category of changes, I manually checked correctness by using images with elements `i -> 1` and `i -> i + 1`.

Let me know what you think, @axtimwalde 