### PR TITLE
Fix off-by-one error with fast clahe

### DIFF
--- a/mpicbg/src/main/java/mpicbg/ij/clahe/FastFlat.java
+++ b/mpicbg/src/main/java/mpicbg/ij/clahe/FastFlat.java
@@ -99,7 +99,7 @@ public class FastFlat extends Flat
 	}
 	
 	
-	final static private int[] createHistogram(
+	static private int[] createHistogram(
 			final int blockRadius,
 			final int bins,
 			final int blockXCenter,
@@ -239,7 +239,7 @@ public class FastFlat extends Flat
 			}
 			
 			final int yMin = ( r == 0 ? 0 : rs[ r0 ] );
-			final int yMax = ( r < rs.length ? rs[ r1 ] : ip.getHeight() - 1 );
+			final int yMax = ( r < rs.length ? rs[ r1 ] : ip.getHeight() );
 			
 			for ( int c = 0; c <= cs.length; ++c )
 			{
@@ -264,7 +264,7 @@ public class FastFlat extends Flat
 				}
 				
 				final int xMin = ( c == 0 ? 0 : cs[ c0 ] );
-				final int xMax = ( c < cs.length ? cs[ c1 ] : ip.getWidth() - 1 );
+				final int xMax = ( c < cs.length ? cs[ c1 ] : ip.getWidth() );
 				
 				for ( int y = yMin; y < yMax; ++y )
 				{


### PR DESCRIPTION
This PR fixes a minor off-by-one error of the "fast CLAHE" algorithm: the last column and row were not corrected before. I noticed this when correcting and reslicing a stack, which resulted in the last slice not being corrected.

This is a zoom-in of the lower right corner of the 'boats' image, treated with fast CLAHE (left) and normal CLAHE (right). Note the dark right and bottom pixels.

![image](https://github.com/user-attachments/assets/96a2579e-1de2-44d7-8631-99f56ef6a333)
 
To reproduce, execute this:
```
final ImageJ ij = new ImageJ();
final ImagePlus imp = IJ.openImage("http://imagej.net/images/boats.gif");
imp.setRoi(26,20,668,543);
final ImagePlus cropped = imp.resize(668, 543, "bilinear");
cropped.setTitle("Original");
cropped.show();

final ImagePlus clahed = cropped.duplicate();
clahed.setTitle("CLAHE");
Flat.getInstance().run(clahed, 127, 256, 3.0f, null, false);
clahed.show();

final ImagePlus fastClahed = cropped.duplicate();
fastClahed.setTitle("Fast CLAHE");
Flat.getFastInstance().run(fastClahed, 127, 256, 3.0f, null, false);
fastClahed.show();
```

Tagging @axtimwalde and @StephanPreibisch for discussion.