### PR TITLE
Fix/integral image oob

### DIFF
--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
@@ -90,10 +90,10 @@ final public class BlockPMCC
 		/* columns */
 		final double[] columnSum = new double[width];
 		final double[] columnSumOfSquares = new double[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];
@@ -145,10 +145,10 @@ final public class BlockPMCC
 		final double[] columnSumOfSquares1 = new double[width];
 		final double[] columnSum2 = new double[width];
 		final double[] columnSumOfSquares2 = new double[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum1[i] += sum1[index];
 				sum1[index] = columnSum1[i];

--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockPMCC.java
@@ -88,17 +88,16 @@ final public class BlockPMCC
 		}
 
 		/* columns */
-		final double[] columnSum = new double[width];
-		final double[] columnSumOfSquares = new double[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
-				columnSumOfSquares[i] += sumOfSquares[index];
-				sumOfSquares[index] = columnSumOfSquares[i];
+				final int index = rowOffset + i;
+				final int indexAbove = prevRowOffset + i;
+
+				sum[index] += sum[indexAbove];
+				sumOfSquares[index] += sumOfSquares[indexAbove];
 			}
 		}
 	}
@@ -141,24 +140,18 @@ final public class BlockPMCC
 		}
 
 		/* columns */
-		final double[] columnSum1 = new double[width];
-		final double[] columnSumOfSquares1 = new double[width];
-		final double[] columnSum2 = new double[width];
-		final double[] columnSumOfSquares2 = new double[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum1[i] += sum1[index];
-				sum1[index] = columnSum1[i];
-				columnSumOfSquares1[i] += sumOfSquares1[index];
-				sumOfSquares1[index] = columnSumOfSquares1[i];
+				final int index = rowOffset + i;
+				final int indexAbove = prevRowOffset + i;
 
-				columnSum2[i] += sum2[index];
-				sum2[index] = columnSum2[i];
-				columnSumOfSquares2[i] += sumOfSquares2[index];
-				sumOfSquares2[index] = columnSumOfSquares2[i];
+				sum1[index] += sum1[indexAbove];
+				sumOfSquares1[index] += sumOfSquares1[indexAbove];
+				sum2[index] += sum2[indexAbove];
+				sumOfSquares2[index] += sumOfSquares2[indexAbove];
 			}
 		}
 	}

--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockStatistics.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockStatistics.java
@@ -163,13 +163,12 @@ public class BlockStatistics
 			final double[] sumOfSquares )
 	{
 		final int width = w - 1;
-		final int height = h - 1;
 		final double[] columnSum = new double[width];
 		final double[] columnSumOfSquares = new double[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];

--- a/mpicbg/src/main/java/mpicbg/ij/integral/BlockStatistics.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/BlockStatistics.java
@@ -163,17 +163,15 @@ public class BlockStatistics
 			final double[] sumOfSquares )
 	{
 		final int width = w - 1;
-		final double[] columnSum = new double[width];
-		final double[] columnSumOfSquares = new double[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
-				columnSumOfSquares[i] += sumOfSquares[index];
-				sumOfSquares[index] = columnSumOfSquares[i];
+				final int index = rowOffset + i;
+				final int indexAbove = prevRowOffset + i;
+				sum[index] += sum[indexAbove];
+				sumOfSquares[index] += sumOfSquares[indexAbove];
 			}
 		}
 	}

--- a/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
@@ -90,14 +90,12 @@ final public class DoubleIntegralImage implements IntegralImage
 		}
 
 		/* columns */
-		final double[] columnSum = new double[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
+				sum[rowOffset + i] += sum[prevRowOffset + i];
 			}
 		}
 	}
@@ -163,14 +161,12 @@ final public class DoubleIntegralImage implements IntegralImage
 		}
 		
 		/* columns */
-		final double[] columnSum = new double[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
+				sum[rowOffset + i] += sum[prevRowOffset + i];
 			}
 		}
 	}

--- a/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/DoubleIntegralImage.java
@@ -91,10 +91,10 @@ final public class DoubleIntegralImage implements IntegralImage
 
 		/* columns */
 		final double[] columnSum = new double[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];
@@ -164,10 +164,10 @@ final public class DoubleIntegralImage implements IntegralImage
 		
 		/* columns */
 		final double[] columnSum = new double[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];

--- a/mpicbg/src/main/java/mpicbg/ij/integral/IntIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/IntIntegralImage.java
@@ -82,10 +82,10 @@ final public class IntIntegralImage implements IntegralImage
 
 		/* columns */
 		final int[] columnSum = new int[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];
@@ -137,10 +137,10 @@ final public class IntIntegralImage implements IntegralImage
 
 		/* columns */
 		final int[] columnSum = new int[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];

--- a/mpicbg/src/main/java/mpicbg/ij/integral/IntIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/IntIntegralImage.java
@@ -81,14 +81,12 @@ final public class IntIntegralImage implements IntegralImage
 		}
 
 		/* columns */
-		final int[] columnSum = new int[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
+				sum[rowOffset + i] += sum[prevRowOffset + i];
 			}
 		}
 	}
@@ -136,14 +134,12 @@ final public class IntIntegralImage implements IntegralImage
 		}
 
 		/* columns */
-		final int[] columnSum = new int[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
+				sum[rowOffset + i] += sum[prevRowOffset + i];
 			}
 		}
 	}

--- a/mpicbg/src/main/java/mpicbg/ij/integral/LongIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/LongIntegralImage.java
@@ -89,14 +89,12 @@ final public class LongIntegralImage implements IntegralImage
 		}
 
 		/* columns */
-		final long[] columnSum = new long[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
+				sum[rowOffset + i] += sum[prevRowOffset + i];
 			}
 		}
 	}
@@ -144,14 +142,12 @@ final public class LongIntegralImage implements IntegralImage
 		}
 
 		/* columns */
-		final long[] columnSum = new long[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
-				columnSum[i] += sum[index];
-				sum[index] = columnSum[i];
+				sum[rowOffset + i] += sum[prevRowOffset + i];
 			}
 		}
 	}

--- a/mpicbg/src/main/java/mpicbg/ij/integral/LongIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/LongIntegralImage.java
@@ -90,10 +90,10 @@ final public class LongIntegralImage implements IntegralImage
 
 		/* columns */
 		final long[] columnSum = new long[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];
@@ -145,10 +145,10 @@ final public class LongIntegralImage implements IntegralImage
 
 		/* columns */
 		final long[] columnSum = new long[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 				columnSum[i] += sum[index];
 				sum[index] = columnSum[i];

--- a/mpicbg/src/main/java/mpicbg/ij/integral/LongRGBIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/LongRGBIntegralImage.java
@@ -97,10 +97,10 @@ final public class LongRGBIntegralImage implements IntegralImage
 		final long[] columnSumR = new long[width];
 		final long[] columnSumG = new long[width];
 		final long[] columnSumB = new long[width];
-		for (int j = 1; j < w; ++j) {
+		for (int j = 1; j < h; ++j) {
 			final int offset = j * w + 1;
 
-			for (int i = 0; i < height; ++i) {
+			for (int i = 0; i < width; ++i) {
 				final int index = offset + i;
 
 				columnSumR[i] += sumR[index];

--- a/mpicbg/src/main/java/mpicbg/ij/integral/LongRGBIntegralImage.java
+++ b/mpicbg/src/main/java/mpicbg/ij/integral/LongRGBIntegralImage.java
@@ -94,21 +94,17 @@ final public class LongRGBIntegralImage implements IntegralImage
 		}
 
 		/* columns */
-		final long[] columnSumR = new long[width];
-		final long[] columnSumG = new long[width];
-		final long[] columnSumB = new long[width];
 		for (int j = 1; j < h; ++j) {
-			final int offset = j * w + 1;
+			final int rowOffset = j * w + 1;
+			final int prevRowOffset = rowOffset - w;
 
 			for (int i = 0; i < width; ++i) {
-				final int index = offset + i;
+				final int index = rowOffset + i;
+				final int indexAbove = prevRowOffset + i;
 
-				columnSumR[i] += sumR[index];
-				sumR[index] = columnSumR[i];
-				columnSumG[i] += sumG[index];
-				sumG[index] = columnSumG[i];
-				columnSumB[i] += sumB[index];
-				sumB[index] = columnSumB[i];
+				sumR[index] += sumR[indexAbove];
+				sumG[index] += sumG[indexAbove];
+				sumB[index] += sumB[indexAbove];
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes a bug where the following minimal example throws a `java.lang.ArrayIndexOutOfBoundsException`
```Java
final FloatProcessor ip = new ij.process.FloatProcessor(123, 34);
final NormalizeLocalContrast normalizer = new NormalizeLocalContrast(ip);                                                                      
normalizer.run(12, 21, 3, true, true);
```

The cause of the bug was that the loop bounds for column and row traversal in the column accumulation code were swapped. This occurred in many places throughout the code base. I cross checked with the changed files in #79, so I hope I've caught all occurrences now.

Thanks @axtimwalde for catching that bug!